### PR TITLE
build(bridge): introduce dockerfile

### DIFF
--- a/.github/workflows/push-docker-image.yaml
+++ b/.github/workflows/push-docker-image.yaml
@@ -1,0 +1,15 @@
+on: push
+name: push docker image
+jobs:
+  build_and_push:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2.3.4
+      - name: login
+        run: docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: build
+        run: docker build -t planetariumhq/9c-ethereum-bridge:git-${{ github.sha }} .
+        working-directory: bridge
+      - name: push (publish)
+        run: docker push planetariumhq/9c-ethereum-bridge:git-${{ github.sha }}

--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:12.22 AS build-env
+
+COPY . /build
+WORKDIR /build
+RUN npm install -D
+RUN npx tsc
+
+FROM node:12-alpine
+
+COPY --from=build-env /build/dist /app
+COPY --from=build-env /build/node_modules /app/node_modules
+WORKDIR /app
+ENTRYPOINT ["node", "index.js"]

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -7,3 +7,9 @@ This application relays between `wNCG` on [Ethereum] and `NCG` on Nine Chronicle
 ```
 npm run start
 ```
+
+## Build (Docker)
+
+```
+docker build .
+```


### PR DESCRIPTION
This pull request resolves #10.

 - Introduce Dockerfile to build as Docker image.
 - Build Docker image and push it to Docker Hub automatically for each push (merge).