### PR TITLE
feat(bridge): log with its class name as prefix

### DIFF
--- a/bridge/src/confirmation-monitor.ts
+++ b/bridge/src/confirmation-monitor.ts
@@ -28,7 +28,7 @@ export abstract class ConfirmationMonitor<TEventData> extends Monitor<TEventData
             const confrimedLatestBlockNumber = Math.max(networkLatestBlockNumber - this._confirmations, beforeLatestBlockNumber);
 
             if (beforeLatestBlockNumber < confrimedLatestBlockNumber) {
-                console.debug(`Trying to look up from ${beforeLatestBlockNumber} to ${confrimedLatestBlockNumber}`);
+                this.debug(`Trying to look up from ${beforeLatestBlockNumber} to ${confrimedLatestBlockNumber}`);
                 const eventLogs = await this.getEvents(beforeLatestBlockNumber, confrimedLatestBlockNumber);
                 for (const eventLog of eventLogs) {
                     yield eventLog;
@@ -36,11 +36,15 @@ export abstract class ConfirmationMonitor<TEventData> extends Monitor<TEventData
 
                 this.latestBlockNumber = confrimedLatestBlockNumber + 1;
             } else {
-                console.debug("Skipped...");
+                this.debug("Skipped...");
             }
 
             await delay(this._delayMilliseconds);
         }
+    }
+
+    private debug(message?: any, ...optionalParams: any[]): void {
+        console.debug(`[${this.constructor.name}]`, message, ...optionalParams);
     }
 
     protected abstract getTipIndex(): Promise<number>;


### PR DESCRIPTION
It resolves #19. 

After this pull request, it logs message like:

```
[NineChroniclesTransferredEventMonitor] Skipped...
[EthereumBurnEventMonitor] Skipped...
[NineChroniclesTransferredEventMonitor] Skipped...
[EthereumBurnEventMonitor] Skipped...
```