### PR TITLE
fix(bridge): correct mint transaction hash log

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,9 +17,7 @@ jobs:
       working-directory: ./bridge
     - run: npm run coverage
       working-directory: ./bridge
-    - run: |
-        npm install codecov
-        npx codecov --disable=gcov
+    - run: bash <(curl -s https://codecov.io/bash)
       name: codecov
       working-directory: ./bridge
       env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
       working-directory: ./bridge
     - run: |
         npm install codecov
-        npx codecov
+        npx codecov --disable=gcov
       name: codecov
       working-directory: ./bridge
       env:

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -221,8 +221,8 @@ function combineUrl(url: string, additionalPath: string): string {
                 return;
             }
 
-            const mintTxId = await minter.mint(event.memo, parseFloat(event.amount));
-            console.log("Receipt", mintTxId);
+            const mintTxReceipt = await minter.mint(event.memo, parseFloat(event.amount));
+            console.log("Receipt", mintTxReceipt.transactionHash);
             await monitorStateStore.store(monitorStateStoreKeys.nineChronicles, { blockHash: event.blockHash, txId: event.txId });
             await slackWebClient.chat.postMessage({
                 channel: "#nine-chronicles-bridge-bot",
@@ -238,7 +238,7 @@ function combineUrl(url: string, additionalPath: string): string {
                             },
                             {
                                 title: "Ethereum network transaction",
-                                value: combineUrl(ETHERSCAN_ROOT_URL, `/tx/${mintTxId}`),
+                                value: combineUrl(ETHERSCAN_ROOT_URL, `/tx/${mintTxReceipt.transactionHash}`),
                             },
                             {
                                 title: "sender (NineChronicles)",

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,10 +1,10 @@
 coverage:
-  range: 100
+  range: 100..100
   status:
     project:
       default:
         target: auto
-        threshold: 0
+        threshold: "0"
         base: auto
 
 comment:


### PR DESCRIPTION
This pull request fixes the bridge logs incorrect transaction hash:

![image](https://user-images.githubusercontent.com/26626194/120169643-22584000-c23b-11eb-97b4-368d7b2a31d2.png)
