### PR TITLE
fix(bridge-www): allow 2 places of decimals

### DIFF
--- a/bridge-www/src/App.tsx
+++ b/bridge-www/src/App.tsx
@@ -75,11 +75,11 @@ function App() {
       To : <input type="text" value={ncAddress} onChange={event => { setNcAddress(event.target.value) }}/>
       <br/>
       {
-        contract === null || account === null || amount === null || isNaN(parseInt(amount)) || !isAddress(ncAddress)
+        contract === null || account === null || amount === null || (parseFloat(amount) * 100).toString().indexOf(".") !== -1 || !isAddress(ncAddress)
           ? <b>Fill corret values</b>
           : <button onClick={event => {
             event.preventDefault();            
-            contract.methods.burn(amount, ncAddress).send({ from: account }).then(console.debug)
+            contract.methods.burn(parseFloat(amount) * 100, ncAddress).send({ from: account }).then(console.debug)
           }}>Burn</button>
       }
     </div>

--- a/bridge-www/src/components/WrappedNcgBalance.tsx
+++ b/bridge-www/src/components/WrappedNcgBalance.tsx
@@ -16,6 +16,6 @@ export const WrappedNcgBalance: React.FC<WrappedNcgBalanceProps> = ({ address, b
     if (balance === null) {
         return <b>🕑</b>
     } else {
-        return <b>{balance}</b>;
+        return <b>{parseInt(balance) / 100}</b>;
     }
 }


### PR DESCRIPTION
Before this pull request, the *bridge-www* application hasn't been showing wNCG amount as float. So users did input `100` to exchange 100 wNCG with 1 NCG. It can occur users confused so this pull request fixed it by presenting it as float.

1. Prepare MetaMask account having some wNCG.
2. Checkout this pull request and run `yarn start` to use bridge-www app.
    - Connect MetaMask to your local bridge-www app if it is not connected yet.
3. Check your wNCG was represented as decimal.

![image](https://user-images.githubusercontent.com/26626194/127284273-ea5509a2-31a0-497a-9f57-84d1f710f99b.png)
![image](https://user-images.githubusercontent.com/26626194/127284296-c6c8ae2f-8bdf-4dab-8179-f9eb9c761759.png)
![image](https://user-images.githubusercontent.com/26626194/127284310-f14b382a-e0d5-4f36-b9f1-17f2546b9522.png)
