### PR TITLE
fix(bridge-www): update amount if wallet changed

### DIFF
--- a/bridge-www/src/App.tsx
+++ b/bridge-www/src/App.tsx
@@ -25,6 +25,12 @@ function App() {
     ? new web3.eth.Contract(wNCGAbi, contractAddress)
     : null,
     [web3, validContractAddress, contractAddress]);
+  function loadAccounts(web3: Web3) {
+    web3.eth.requestAccounts().then(accounts => {
+      setAccounts(accounts);
+      setAccount(accounts[0]);
+    });
+  }
 
   useEffect(() => {
     if (window.ethereum === undefined || !window.ethereum.isMetaMask) {
@@ -32,20 +38,14 @@ function App() {
     } else {
       // FIXME: ethereum.enable() method was deprecated. Use ethereum.request(...) method.
       window.ethereum.enable();
-      setWeb3(new Web3(window.ethereum as Provider))
+      const web3 = new Web3(window.ethereum as Provider);
+      setWeb3(web3)
+      window.ethereum.on("accountsChanged", (accounts) => {
+        loadAccounts(web3);
+      });
+      loadAccounts(web3);
     }
   }, []);
-
-  useEffect(() => {
-    if (web3 === null) {
-      return;
-    }
-
-    web3.eth.requestAccounts().then(accounts => {
-      setAccounts(accounts);
-      setAccount(accounts[0]);
-    });
-  }, [web3]);
 
 
   if (web3 === null) {


### PR DESCRIPTION
Before this pull request, it did nothing when the MetaMask's wallet changed.
This pull request makes it update wNCG's amount if the Metamask wallet changed.

1. Prepare multiple metamask accounts having different amount of wNCG.
2. Checkout this pull request and run `yarn start` to use bridge-www app.
  - Connect MetaMask to your local bridge-www app if it is not connected yet.
3. Change your MetaMask wallets and see the amount changes.

## Screenshots
![image](https://user-images.githubusercontent.com/26626194/127288649-314e401a-a356-4c8c-a067-5dfeb191c7b2.png)
![image](https://user-images.githubusercontent.com/26626194/127288688-a71f755d-c3ff-41ac-a265-7b2be4266203.png)
![image](https://user-images.githubusercontent.com/26626194/127288739-d7947ca6-90bc-468a-8bc3-27934494336f.png)

