### PR TITLE
fix(bridge): avoid invalid cast for null memo

### DIFF
--- a/bridge/src/ncg-kms-transfer.ts
+++ b/bridge/src/ncg-kms-transfer.ts
@@ -50,7 +50,7 @@ export class NCGKMSTransfer implements INCGTransfer {
                         },
                         parseInt(amount)
                     ],
-                    memo: memo,
+                    ...(memo === null ? {} : { memo }),
                     recipient: Buffer.from(web3.utils.hexToBytes(address)),
                     sender: Buffer.from(web3.utils.hexToBytes(this._address))
                 }


### PR DESCRIPTION
Before this pull request, `NCGKMSTransfer` included `memo` field though it was `null` into `TransferAsset` plain value.
But on Lib9c side, it hasn't include it if it is `null`. This pull request fixes the bug.