### PR TITLE
docs(bridge): correct .env.example descriptions 

### DIFF
--- a/bridge/.env.example
+++ b/bridge/.env.example
@@ -2,10 +2,6 @@
 # Its hostname and port should match with HTTP_ROOT_API_ENDPOINT's hostname and port.
 GRAPHQL_API_ENDPOINT="http://localhost:23061/graphql"
 
-# The chain ID where bridge application run.
-# You can see EIP-155 https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#list-of-chain-ids
-CHAIN_ID=1
-
 # The Sentry DSN url to enable Sentry.
 # If you don't want to use Sentry, remove this envirionment variable.
 SENTRY_DSN="https://examplePublicKey@o0.ingest.sentry.io/0"
@@ -26,8 +22,17 @@ EXPLORER_ROOT_URL="https://explorer.libplanet.io/9c-internal/"
 # For instance, https://ropsten.etherscan.io/, https://etherscan.io/
 ETHERSCAN_ROOT_URL="https://ropsten.etherscan.io/"
 
-# TODO: it should be documented.
+# The provider's url to interact with Ethereum. You can usually use Infura for it.
+# This provider will determine the network to use calling 'net_version' in `KmsProvider`.
+# If you use https://mainnet.infura.io/v3/..., it will work on mainnet.
+# And, if you use https://ropsten.infura.io/v3/..., it will work on ropsten.
+# You can see:
+# - https://github.com/odanado/aws-kms-provider/blob/89611ba70fed360a01f2ef6b5b3a03d7e97b01f8/src/provider.ts#L175-L188
+# - https://github.com/odanado/aws-kms-provider/blob/89611ba70fed360a01f2ef6b5b3a03d7e97b01f8/src/ethereum.ts#L17-L24
+# - https://eth.wiki/json-rpc/API#net_version
 KMS_PROVIDER_URL=
+
+# TODO: it should be documented.
 KMS_PROVIDER_KEY_ID=
 KMS_PROVIDER_REGION=
 KMS_PROVIDER_AWS_ACCESSKEY=

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -35,7 +35,6 @@ import { NCGKMSTransfer } from "./ncg-kms-transfer";
     const SLACK_WEB_TOKEN: string = Configuration.get("SLACK_WEB_TOKEN");
     const EXPLORER_ROOT_URL: string = Configuration.get("EXPLORER_ROOT_URL");
     const ETHERSCAN_ROOT_URL: string = Configuration.get("ETHERSCAN_ROOT_URL");
-    const DEBUG: boolean = Configuration.get("DEBUG", false, "boolean");
     const SENTRY_DSN: string | undefined = Configuration.get("SENTRY_DSN", false);
     if (SENTRY_DSN !== undefined) {
         init({
@@ -97,11 +96,7 @@ import { NCGKMSTransfer } from "./ncg-kms-transfer";
 
     const ncgTransferredEventObserver = new NCGTransferredEventObserver(ncgKmsTransfer, minter, slackWebClient, monitorStateStore, EXPLORER_ROOT_URL, ETHERSCAN_ROOT_URL);
     const nineChroniclesMonitor = new NineChroniclesTransferredEventMonitor(await monitorStateStore.load("nineChronicles"), 50, headlessGraphQLCLient, kmsAddress);
-    // chain id, 1, means mainnet. See EIP-155, https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#specification.
-    // It should be not able to run in mainnet because it is for test.
-    if (DEBUG && CHAIN_ID !== 1) {
-        nineChroniclesMonitor.attach(ncgTransferredEventObserver);
-    }
+    nineChroniclesMonitor.attach(ncgTransferredEventObserver);
 
     ethereumBurnEventMonitor.run();
     nineChroniclesMonitor.run();


### PR DESCRIPTION
Because the mainnet operation is coming closer, this pull request tried to remove the code to prevent running in mainnet.
But, since #46, the network has been determined by `KMS_PROVIDER_URL` defaultly. So, because the code and .env.example descriptions were staled, this pull request fixes it.