### PR TITLE
fix(bridge): correct authorized block index calculation

### DIFF
--- a/bridge/src/monitors/nine-chronicles-transferred-event-monitor.ts
+++ b/bridge/src/monitors/nine-chronicles-transferred-event-monitor.ts
@@ -20,7 +20,7 @@ export class NineChroniclesTransferredEventMonitor extends TriggerableMonitor<NC
     protected async processRemains(transactionLocation: TransactionLocation) {
         const blockHash = transactionLocation.blockHash;
         const blockIndex = await this.getBlockIndex(transactionLocation.blockHash);
-        const authorizedBlockIndex = Math.floor((blockIndex + AUTHORIZED_BLOCK_INTERVAL) / AUTHORIZED_BLOCK_INTERVAL) * AUTHORIZED_BLOCK_INTERVAL;
+        const authorizedBlockIndex = Math.floor((blockIndex + AUTHORIZED_BLOCK_INTERVAL - 1) / AUTHORIZED_BLOCK_INTERVAL) * AUTHORIZED_BLOCK_INTERVAL;
         const remainedEvents: { blockHash: string; events: any[]; }[] = Array(authorizedBlockIndex - blockIndex + 1);
         const events = await this.getEvents(blockIndex);
         const returnEvents = [];


### PR DESCRIPTION
Originally, I expected authorized block index calculation in `processRemains` function to map 1..50 → 50, 51..100 → 100 but it mapped like 1..49 → 50, 50..99 → 100. It causes bug to make bridge read non-existent block when restarting. This pull request fixes the incorrect calculation.