### PR TITLE
feat(bridge): bump node image

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:12.22 AS build-env
+FROM node:14.17 AS build-env
 
 COPY . /build
 WORKDIR /build
 RUN npm install -D
 RUN npx tsc --project tsconfig.production.json
 
-FROM node:12-alpine
+FROM node:14.17-alpine
 
 COPY --from=build-env /build/dist /app
 COPY --from=build-env /build/node_modules /app/node_modules


### PR DESCRIPTION
This pull request bumps nodejs runtime version into 14.17 from 12. Current docker image doesn't work because nodejs 12 doesn't support `??` operator.