### PR TITLE
fix(bridge): correct log message

### DIFF
--- a/bridge/src/observers/nine-chronicles.ts
+++ b/bridge/src/observers/nine-chronicles.ts
@@ -105,7 +105,7 @@ export class NCGTransferredEventObserver implements IObserver<{ blockHash: Block
                 // NOTE x.cmp(y) returns -1, means x < y.
                 if (alreadyExchangedUptoMaximum) {
                     const nineChroniclesTxId = await this._ncgTransfer.transfer(sender, amountString, `I'm bridge and you can exchange until ${this._limitationPolicy.maximum} for 24 hours.`);
-                    console.log(`${sender} already exchanged ${amountString} and users can exchange until ${this._limitationPolicy.maximum} in 24 hours so refund NCG as ${amountString}. The transaction's id is`, nineChroniclesTxId);
+                    console.log(`${sender} already exchanged ${transferredAmountInLast24Hours} and users can exchange until ${this._limitationPolicy.maximum} in 24 hours so refund NCG as ${amountString}. The transaction's id is`, nineChroniclesTxId);
                     continue;
                 }
 


### PR DESCRIPTION
Originally, there was typo.
If someone tried to exchange `1000` and the one already exchanged `50000` NCG and maximum is `10000`,

it printed:

`0xaaaa already exchanged 1000 and users can exchange until 1000 in 24 hours so refund NCG as 1000`.

But it should be:

`0xaaaa already exchanged 50000 and users can exchange until 1000 in 24 hours so refund NCG as 1000`. 

This pull request fixed it.