### PR TITLE
fix(bridge): bump transfer_asset version

### DIFF
--- a/bridge/src/ncg-kms-transfer.ts
+++ b/bridge/src/ncg-kms-transfer.ts
@@ -44,8 +44,10 @@ export class NCGKMSTransfer implements INCGTransfer {
         // If 50.011 came as `amount`, expect 5001.
         const ncgAmount = new Decimal(amount).mul(100).floor().toNumber();
         return await this._mutex.runExclusive(async () => {
+            // FIXME: request unsigned transaction builder API to NineChronicles.Headless developer
+            //        and remove these lines.
             const plainValue = {
-                type_id: "transfer_asset",
+                type_id: "transfer_asset2",
                 values: {
                     amount: [
                         {


### PR DESCRIPTION
Since NineChronicles network v100080, all actions except for the latest version actions were obsoleted and became not able to be executed. So, this pull request bumps the `transfer_asset` action into `transfer_asset2`.