### PR TITLE
feat(bridge): log transaction hash before processing

### DIFF
--- a/bridge/src/observers/burn-event-observer.ts
+++ b/bridge/src/observers/burn-event-observer.ts
@@ -41,6 +41,7 @@ export class EthereumBurnEventObserver implements IObserver<{ blockHash: BlockHa
             const amountString = amount.toFixed(2, Decimal.ROUND_DOWN);
 
             try {
+                console.log("Process Ethereum transaction", transactionHash);
                 const nineChroniclesTxId = await this._ncgTransfer.transfer(recipient, amountString, transactionHash);
 
                 await this._monitorStateStore.store("ethereum", { blockHash, txId: transactionHash });

--- a/bridge/src/observers/nine-chronicles.ts
+++ b/bridge/src/observers/nine-chronicles.ts
@@ -63,6 +63,8 @@ export class NCGTransferredEventObserver implements IObserver<{ blockHash: Block
         let recorded = false;
         for (const { blockHash, txId, sender, amount: amountString, memo: recipient, } of events) {
             try {
+                console.log("Process NineChronicles transaction", txId);
+
                 if (this._addressBanPolicy.isBannedAddress(sender)) {
                     continue;
                 }


### PR DESCRIPTION
For log analytics, it starts to log transaction hash (i.e. transaction id).