### PR TITLE
fix(bridge): correct error message when object was thrown

### DIFF
--- a/bridge/src/observers/nine-chronicles.ts
+++ b/bridge/src/observers/nine-chronicles.ts
@@ -164,10 +164,8 @@ export class NCGTransferredEventObserver implements IObserver<{ blockHash: Block
                 let errorMessage: string;
                 if (e instanceof Error) {
                     errorMessage = String(e);
-                } else if (e instanceof Object) {
-                    errorMessage = JSON.stringify(e);
                 } else {
-                    errorMessage = String(e);
+                    errorMessage = JSON.stringify(e);
                 }
 
                 // TODO: it should be replaced with `Integration` Slack implementation.

--- a/bridge/src/observers/nine-chronicles.ts
+++ b/bridge/src/observers/nine-chronicles.ts
@@ -161,13 +161,22 @@ export class NCGTransferredEventObserver implements IObserver<{ blockHash: Block
                 });
             } catch (e) {
                 console.log("EERRRR", e)
+                let errorMessage: string;
+                if (e instanceof Error) {
+                    errorMessage = String(e);
+                } else if (e instanceof Object) {
+                    errorMessage = JSON.stringify(e);
+                } else {
+                    errorMessage = String(e);
+                }
+
                 // TODO: it should be replaced with `Integration` Slack implementation.
                 await this._slackWebClient.chat.postMessage({
                     channel: "#nine-chronicles-bridge-bot",
-                    ...new WrappingFailureEvent(this._explorerUrl, sender, String(recipient), amountString, txId, String(e)).render()
+                    ...new WrappingFailureEvent(this._explorerUrl, sender, String(recipient), amountString, txId, errorMessage).render()
                 });
                 await this._integration.error("Unexpected error during wrapping NCG", {
-                    errorMessage: String(e),
+                    errorMessage,
                     sender,
                     recipient,
                     txId,

--- a/bridge/test/observers/__snapshots__/nine-chronicles.spec.ts.snap
+++ b/bridge/test/observers/__snapshots__/nine-chronicles.spec.ts.snap
@@ -43,7 +43,7 @@ Array [
             },
             Object {
               "title": "error",
-              "value": "Error: mockWrappedNcgMinter.mint error",
+              "value": "{\\"code\\":-32000,\\"message\\":\\"err: max fee per gas less than block base fee: address 0x9093dd96c4bb6b44A9E0A522e2DE49641F146223, maxFeePerGas: 300000000000 baseFee: 305545815494 (supplied gas 11118348)\\"}",
             },
           ],
         },
@@ -98,6 +98,8 @@ Array [
   ],
 ]
 `;
+
+exports[`NCGTransferredEventObserver notify slack object error message - snapshot 1`] = `Array []`;
 
 exports[`NCGTransferredEventObserver notify slack refund error message - snapshot 1`] = `
 Array [

--- a/bridge/test/observers/__snapshots__/nine-chronicles.spec.ts.snap
+++ b/bridge/test/observers/__snapshots__/nine-chronicles.spec.ts.snap
@@ -140,3 +140,5 @@ Array [
   ],
 ]
 `;
+
+exports[`NCGTransferredEventObserver notify slack string error message - snapshot 1`] = `Array []`;

--- a/bridge/test/observers/nine-chronicles.spec.ts
+++ b/bridge/test/observers/nine-chronicles.spec.ts
@@ -431,6 +431,31 @@ describe(NCGTransferredEventObserver.name, () => {
             expect(mockSlackWebClient.chat.postMessage.mock.calls).toMatchSnapshot();
         });
 
+        it("slack object error message - snapshot", async () => {
+            mockWrappedNcgMinter.mint.mockImplementationOnce(() => {
+                throw {
+                    code: -32000,
+                    message: 'err: max fee per gas less than block base fee: address 0x9093dd96c4bb6b44A9E0A522e2DE49641F146223, maxFeePerGas: 300000000000 baseFee: 305545815494 (supplied gas 11118348)'
+                };
+            });
+
+            await observer.notify({
+                blockHash: "BLOCK-HASH",
+                events: [
+                    {
+                        amount: "1.23",
+                        memo: "0x0000000000000000000000000000000000000000",
+                        blockHash: "BLOCK-HASH",
+                        txId: "TX-ID",
+                        recipient: "0x6d29f9923C86294363e59BAaA46FcBc37Ee5aE2e",
+                        sender: "0x2734048eC2892d111b4fbAB224400847544FC872",
+                    },
+                ],
+            });
+
+            expect(mockSlackWebClient.chat.postMessage.mock.calls).toMatchSnapshot();
+        });
+
         it("slack ethereum transfer error message - snapshot", async () => {
             mockWrappedNcgMinter.mint.mockImplementationOnce((address, amount) => {
                 throw new Error("mockWrappedNcgMinter.mint error");

--- a/bridge/test/observers/nine-chronicles.spec.ts
+++ b/bridge/test/observers/nine-chronicles.spec.ts
@@ -70,6 +70,10 @@ describe(NCGTransferredEventObserver.name, () => {
     const observer = new NCGTransferredEventObserver(mockNcgTransfer, mockWrappedNcgMinter, mockSlackWebClient, mockMonitorStateStore, mockExchangeHistoryStore, "https://explorer.libplanet.io/9c-internal", "https://ropsten.etherscan.io", exchangeFeeRatio, limitationPolicy, addressBanPolicy, mockIntegration);
 
     describe(NCGTransferredEventObserver.prototype.notify.name, () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
         it("should record the block hash even if there is no events", () => {
             observer.notify({
                 blockHash: "BLOCK-HASH",
@@ -498,6 +502,27 @@ describe(NCGTransferredEventObserver.name, () => {
             });
 
             expect(mockIntegration.error.mock.calls).toMatchSnapshot();
+        });
+
+        // Try to catch cases when others, not object and error, were thrown.
+        it("slack string error message - snapshot", async () => {
+            mockWrappedNcgMinter.mint.mockRejectedValueOnce("error message");
+
+            await observer.notify({
+                blockHash: "BLOCK-HASH",
+                events: [
+                    {
+                        amount: "1.23",
+                        memo: "0x0000000000000000000000000000000000000000",
+                        blockHash: "BLOCK-HASH",
+                        txId: "TX-ID",
+                        recipient: "0x6d29f9923C86294363e59BAaA46FcBc37Ee5aE2e",
+                        sender: "0x2734048eC2892d111b4fbAB224400847544FC872",
+                    },
+                ],
+            });
+
+            expect(mockSlackWebClient.chat.postMessage.mock.calls).toMatchSnapshot();
         });
     })
 })


### PR DESCRIPTION
The bridge application has sent Slack messages and PagerDuty alerts when an error is thrown. But when Web3.js threw an object as an error, we could see just `[object Object]`. This pull request makes us see detail values well. You can check it in snapshot files in changes.

<img width="230" alt="image" src="https://user-images.githubusercontent.com/26626194/139178517-7d3e0b75-a5b8-4d47-8d29-1838cdd5f922.png">

If it reverts these changes, then the snapshot test will fail with the below message.
```
    -               "value": "{\"code\":-32000,\"message\":\"err: max fee per gas less than block base fee: address 0x9093dd96c4bb6b44A9E0A522e2DE49641F146223, maxFeePerGas: 300000000000 baseFee: 305545815494 (supplied gas 11118348)\"}",
    +               "value": "[object Object]",
```