### PR TITLE
feat(scripts): introduce check-dropped-refund-transactions script

### DIFF
--- a/scripts/check-dropped-refund-transaction.py
+++ b/scripts/check-dropped-refund-transaction.py
@@ -1,0 +1,64 @@
+from typing import Optional
+import requests
+import sys
+
+if len(sys.argv) < 1:
+    print(sys.argv[0], "[LOGFILE]")
+    exit(-1)
+
+LOGFILE = sys.argv[1]
+
+lines = open(LOGFILE).readlines()
+logs = [line for line in lines if "[LOG]" in line]
+
+
+def after(s: str, sub: str):
+    return s[s.index(sub) + len(sub) :]
+
+
+def until(s: str, sub: str):
+    return s[: s.index(sub)]
+
+
+def get_transaction(txid: str) -> Optional[dict]:
+    try:
+        return requests.get(f"https://api.9cscan.com/transactions/{txid}").json()
+    except:
+        return None
+
+
+def try_get_transaction(txid: str):
+    return txid, get_transaction(txid)
+
+
+def get_amount_from_reason(reason: str) -> float:
+    if "The amount" in reason:
+        return float(until(after(reason, "The amount("), ")"))
+    elif "so refund NCG as " in reason:
+        return float(until(after(reason, "so refund NCG as "), ". "))
+    else:
+        raise ValueError(reason)
+
+
+TX_DESCRIPTION_STRING = "The transaction's id is"
+results = [
+    (
+        after(logs[index - 1], "Process NineChronicles transaction ").strip(),
+        after(log, "[LOG]   ").strip(),
+        try_get_transaction(after(log, TX_DESCRIPTION_STRING).strip()),
+    )
+    for index, log in enumerate(logs)
+    if TX_DESCRIPTION_STRING in log
+]
+
+failed_results = [
+    (request_txid, get_amount_from_reason(reason), reason, txid)
+    for (request_txid, reason, (txid, tx)) in results
+    if tx is None
+]
+
+print("request_txid,txid,signer,amount,reason")
+for request_txid, amount, reason, tx in failed_results:
+    request_tx = get_transaction(request_txid)
+    signer = request_tx["signer"]
+    print(request_txid, ",", tx, ",", signer, ",", amount, ",", f'"{reason}"')


### PR DESCRIPTION

# What this pull request does?

This pull request introduces a script to parse, filter and process dropped refund transactions to CSV.

# Background

Currently, there are problems with transaction broadcasting into the 9c main network and there is no way to know all refund transactions until #107. But they should be processed also.