### PR TITLE
feat(bridge-status-bot): apply manual mint transaction

### DIFF
--- a/bridge-status-bot/app.sh
+++ b/bridge-status-bot/app.sh
@@ -40,7 +40,7 @@ TOTAL_SUPPLY=$(get_total_supply)
 GOLD_BALANCE=$(get_gold_balance "$BRIDGE_ADDRESS")
 ETH_BALANCE=$(get_eth_balance "$BRIDGE_ADDRESS")
 
-GAP=$(bc <<< "$TOTAL_SUPPLY - 44073334 - $GOLD_BALANCE")
+GAP=$(bc <<< "$TOTAL_SUPPLY - 54073334 - $GOLD_BALANCE")
 
 TEXT=":notebook: *9c-bridge report*\\n\
 > Currently, there are WNCGs minted manually not through bridge swap process. The total amount is *44,073,334*. So the gap was calculated via:\


### PR DESCRIPTION
This pull request applies to the manual mint transaction.

Planetarium manually minted 10,000,000 WNCG. See https://etherscan.io/tx/0x7505bfe8688b00dfc4aa857fc3a6c900420a382ce8be93e2aee5913fc062bb6e transaction.