### PR TITLE
fix(bridge): correct EIP-1559 transaction's type

### DIFF
--- a/bridge/src/wrapped-ncg-minter.ts
+++ b/bridge/src/wrapped-ncg-minter.ts
@@ -41,6 +41,6 @@ export class WrappedNCGMinter implements IWrappedNCGMinter {
       const gasPriceString = await this._web3.eth.getGasPrice();
       const gasPrice = new Decimal(gasPriceString);
       const calculatedGasPrice = this._gasPricePolicy.calculateGasPrice(gasPrice);
-      return this._contract.methods.mint(address, this._web3.utils.toBN(amount.toString())).send({from: this._minterAddress, gasPrice: calculatedGasPrice.toString(), maxPriorityFeePerGas: this._web3.utils.toWei(this._priorityFee.toString(), "gwei")});
+      return this._contract.methods.mint(address, this._web3.utils.toBN(amount.toString())).send({from: this._minterAddress, gasPrice: calculatedGasPrice.toString(), maxPriorityFeePerGas: this._web3.utils.toWei(this._priorityFee.toString(), "gwei"), type: this._web3.utils.toBN(2)});
     }
 }

--- a/bridge/test/wrapped-ncg-minter.spec.ts
+++ b/bridge/test/wrapped-ncg-minter.spec.ts
@@ -65,6 +65,7 @@ describe(WrappedNCGMinter.name, () => {
                 from: mockMinterAddress,
                 gasPrice: "150",
                 maxPriorityFeePerGas: "1000000000",
+                type: 2,
             })
         });
     });


### PR DESCRIPTION
At web3.js 1.5.2, the default transaction type is `0x00`, not `0x02`. The EIP-1559's transaction type is `0x02` and it should be specified explicitly. This pull request does it.