### PR TITLE
feat(bridge): use `gasPrice` tip again

### DIFF
--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -59,6 +59,9 @@ process.on("uncaughtException", console.error);
     }
     const PRIORITY_FEE: number = Configuration.get("PRIORITY_FEE", true, "float");
 
+    const GAS_TIP_RATIO_STRING: string = Configuration.get("GAS_TIP_RATIO", true, "string");
+    const GAS_TIP_RATIO = new Decimal(GAS_TIP_RATIO_STRING);
+
     const MAX_GAS_PRICE_STRING: string = Configuration.get("MAX_GAS_PRICE", true, "string");
     const MAX_GAS_PRICE = new Decimal(MAX_GAS_PRICE_STRING);
 
@@ -101,7 +104,9 @@ process.on("uncaughtException", console.error);
     const kmsAddress = kmsAddresses[0];
     console.log(kmsAddress);
     const gasPriceLimitPolicy: IGasPricePolicy = new GasPriceLimitPolicy(MAX_GAS_PRICE);
+    const gasPriceTipPolicy: IGasPricePolicy = new GasPriceTipPolicy(GAS_TIP_RATIO);
     const gasPricePolicy: IGasPricePolicy = new GasPricePolicies([
+        gasPriceTipPolicy,
         gasPriceLimitPolicy,
     ]);
     const minter: IWrappedNCGMinter = new WrappedNCGMinter(web3, wNCGToken, kmsAddress, gasPricePolicy, new Decimal(PRIORITY_FEE));

--- a/bridge/src/wrapped-ncg-minter.ts
+++ b/bridge/src/wrapped-ncg-minter.ts
@@ -41,6 +41,6 @@ export class WrappedNCGMinter implements IWrappedNCGMinter {
       const gasPriceString = await this._web3.eth.getGasPrice();
       const gasPrice = new Decimal(gasPriceString);
       const calculatedGasPrice = this._gasPricePolicy.calculateGasPrice(gasPrice);
-      return this._contract.methods.mint(address, this._web3.utils.toBN(amount.toString())).send({from: this._minterAddress, maxPriorityFeePerGas: this._web3.utils.toWei(this._priorityFee.toString(), "gwei"), type: "0x2"});
+      return this._contract.methods.mint(address, this._web3.utils.toBN(amount.toString())).send({from: this._minterAddress, gasPrice: calculatedGasPrice});
     }
 }

--- a/bridge/test/wrapped-ncg-minter.spec.ts
+++ b/bridge/test/wrapped-ncg-minter.spec.ts
@@ -63,8 +63,7 @@ describe(WrappedNCGMinter.name, () => {
             expect(mockContract.methods.mint).toHaveBeenCalledWith("0x1111111111111111111111111111111111111111", 10)
             expect(mockContractMethodReturn.send).toHaveBeenCalledWith({
                 from: mockMinterAddress,
-                maxPriorityFeePerGas: "1000000000",
-                type: "0x2",
+                gasPrice: 150,
             })
         });
     });


### PR DESCRIPTION
#126 deprecated `GAS_TIP_RATIO` but it `EIP-1559` doesn't work well 🤔 So this pull request reverts it for smooth operation.