### PR TITLE
fix(scripts): improve observer

### DIFF
--- a/scripts/observer/__main__.py
+++ b/scripts/observer/__main__.py
@@ -11,7 +11,7 @@ import code
 import slack_sdk
 
 from models import SlackMessage, UnwrappingFailureEvent, WrappingEvent, UnwrappingEvent, WrappingFailureEvent, RefundEvent, Address, TxId
-from ncscan import get_transaction
+from headless import get_transaction
 from parser import parse_slack_response
 
 

--- a/scripts/observer/headless.py
+++ b/scripts/observer/headless.py
@@ -1,0 +1,24 @@
+from typing import Optional
+from models import TxId
+
+import requests
+
+async def get_transaction(txid: TxId) -> Optional[dict]:
+    QUERY = "query { chainQuery { transactionQuery { transaction(id: \"%s\") { signer nonce } } } }" % txid
+
+    response = requests.post(
+        "https://9c-main-full-state.planetarium.dev/graphql",
+        json={
+            "operationName": None,
+            "query": QUERY,
+            "variables": {},
+        }
+    )
+
+    if response.status_code == 200:
+        json = response.json()
+        if "data" not in json:
+            return None
+        return json["data"]["chainQuery"]["transactionQuery"]["transaction"]
+
+    return None


### PR DESCRIPTION
I believe this pull request improves observer:

 - Use Nine Chronicles headless GraphQL API instead 9cscan.
 - Await all handlers. Before this pull request, they didn't work well.