### PR TITLE
feat(bridge): skip if the exchange history already exists

### DIFF
--- a/bridge/src/interfaces/exchange-history-store.ts
+++ b/bridge/src/interfaces/exchange-history-store.ts
@@ -9,6 +9,7 @@ export interface ExchangeHistory {
 
 export interface IExchangeHistoryStore {
     put(history: ExchangeHistory): Promise<void>;
+    exist(tx_id: string): Promise<boolean>;
 
     transferredAmountInLast24Hours(network: string, sender: string): Promise<number>;
 };

--- a/bridge/src/messages/wrapping-retry-ignore-event.ts
+++ b/bridge/src/messages/wrapping-retry-ignore-event.ts
@@ -1,0 +1,30 @@
+import { ChatPostMessageArguments } from "@slack/web-api";
+import { Message } from ".";
+import { TxId } from "../types/txid";
+
+export class WrappingRetryIgnoreEvent implements Message {
+    private readonly _txId: string;
+
+    constructor(txId: TxId) {
+        this._txId = txId;
+    }
+
+    render(): Partial<ChatPostMessageArguments> {
+        return {
+            text: "NCG → wNCG event already seems executed so it skipped.",
+            attachments: [
+                {
+                    author_name: 'Bridge Warning',
+                    color: "#ffcc00",
+                    fields: [
+                        {
+                            title: "9c network transaction id",
+                            value: this._txId,
+                        },
+                    ],
+                    fallback: `NCG → wNCG event already seems executed so it skipped.`
+                }
+            ]
+        }
+    }
+}

--- a/bridge/src/observers/nine-chronicles.ts
+++ b/bridge/src/observers/nine-chronicles.ts
@@ -70,6 +70,10 @@ export class NCGTransferredEventObserver implements IObserver<{ blockHash: Block
                     continue;
                 }
 
+                if (await this._exchangeHistoryStore.exist(txId)) {
+                    continue;
+                }
+
                 const decimals = new Decimal(10).pow(18);
                 const amount = new Decimal(amountString);
                 const minimum = new Decimal(this._limitationPolicy.minimum);

--- a/bridge/src/observers/nine-chronicles.ts
+++ b/bridge/src/observers/nine-chronicles.ts
@@ -11,6 +11,7 @@ import { WrappedEvent } from "../messages/wrapped-event";
 import { RefundEvent } from "../messages/refund-event";
 import Decimal from "decimal.js"
 import { WrappingFailureEvent } from "../messages/wrapping-failure-event";
+import { WrappingRetryIgnoreEvent } from "../messages/wrapping-retry-ignore-event";
 import { IExchangeHistoryStore } from "../interfaces/exchange-history-store";
 import { IAddressBanPolicy } from "../policies/address-ban";
 import { Integration } from "../integrations";
@@ -71,6 +72,10 @@ export class NCGTransferredEventObserver implements IObserver<{ blockHash: Block
                 }
 
                 if (await this._exchangeHistoryStore.exist(txId)) {
+                    this._slackWebClient.chat.postMessage({
+                        channel: "#nine-chronicles-bridge-bot",
+                        ...new WrappingRetryIgnoreEvent(txId).render()
+                    });
                     continue;
                 }
 

--- a/bridge/src/sqlite3-exchange-history-store.ts
+++ b/bridge/src/sqlite3-exchange-history-store.ts
@@ -28,6 +28,15 @@ export class Sqlite3ExchangeHistoryStore implements IExchangeHistoryStore {
             [network, tx_id, sender, recipient, amount, timestamp]);
     }
 
+    async exist(tx_id: string): Promise<boolean> {
+        this.checkClosed();
+
+        const get: (sql: string, params: any[]) => Promise<{ "tx_id": string | null } > = promisify(this._database.get.bind(this._database));
+        const row = await get(
+            "SELECT tx_id FROM exchange_histories WHERE tx_id = ?", [tx_id]);
+        return row !== undefined;
+    }
+
     async transferredAmountInLast24Hours(network: string, sender: string): Promise<number> {
         this.checkClosed();
         const get: (sql: string, params: any[]) => Promise<{ "total_amount": string | null } > = promisify(this._database.get.bind(this._database));

--- a/bridge/test/messages/__snapshots__/wrapping-retry-ignore-event.spec.ts.snap
+++ b/bridge/test/messages/__snapshots__/wrapping-retry-ignore-event.spec.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WrappingRetryIgnoreEvent render snapshot 1`] = `
+Object {
+  "attachments": Array [
+    Object {
+      "author_name": "Bridge Warning",
+      "color": "#ffcc00",
+      "fallback": "NCG → wNCG event already seems executed so it skipped.",
+      "fields": Array [
+        Object {
+          "title": "9c network transaction id",
+          "value": "3409cdbaa24ec6f7c8d2c0f636325a2b2e9611e5e6df5c593cfcd299860d8043",
+        },
+      ],
+    },
+  ],
+  "text": "NCG → wNCG event already seems executed so it skipped.",
+}
+`;

--- a/bridge/test/messages/wrapping-retry-ignore-event.spec.ts
+++ b/bridge/test/messages/wrapping-retry-ignore-event.spec.ts
@@ -1,0 +1,10 @@
+import { WrappingRetryIgnoreEvent } from "../../src/messages/wrapping-retry-ignore-event"
+
+describe("WrappingRetryIgnoreEvent", () => {
+    describe("render", () => {
+        it("snapshot", () => {
+            const TX_ID = "3409cdbaa24ec6f7c8d2c0f636325a2b2e9611e5e6df5c593cfcd299860d8043";
+            expect(new WrappingRetryIgnoreEvent(TX_ID).render()).toMatchSnapshot();
+        });
+    })
+})

--- a/bridge/test/observers/nine-chronicles.spec.ts
+++ b/bridge/test/observers/nine-chronicles.spec.ts
@@ -52,6 +52,7 @@ describe(NCGTransferredEventObserver.name, () => {
     const mockExchangeHistoryStore: jest.Mocked<IExchangeHistoryStore> = {
         put: jest.fn(),
         transferredAmountInLast24Hours: jest.fn(),
+        exist: jest.fn(),
     };
 
     const limitationPolicy = {

--- a/bridge/test/observers/nine-chronicles.spec.ts
+++ b/bridge/test/observers/nine-chronicles.spec.ts
@@ -136,6 +136,32 @@ describe(NCGTransferredEventObserver.name, () => {
             expect(mockWrappedNcgMinter.mint).not.toHaveBeenCalled();
         });
 
+        it("should skip if the exchange history already exists", async () => {
+            mockExchangeHistoryStore.exist.mockImplementationOnce(async (tx_id: string) => {
+                if (tx_id === "TX-ID-A") {
+                    return true;
+                } else {
+                    return false;
+                }
+            });
+
+            await observer.notify({
+                blockHash: "BLOCK-HASH",
+                events: [{
+                    amount: "0",
+                    blockHash: "BLOCK-HASH",
+                    txId: "TX-ID-A",
+                    memo: "0x4029bC50b4747A037d38CF2197bCD335e22Ca301",
+                    recipient: "0x6d29f9923C86294363e59BAaA46FcBc37Ee5aE2e",
+                    sender: BANNED_ADDRESS,
+                }],
+            });
+
+            expect(mockMonitorStateStore.store).toHaveBeenCalledWith("nineChronicles", {blockHash: "BLOCK-HASH", txId: null});
+            expect(mockNcgTransfer.transfer).not.toHaveBeenCalled();
+            expect(mockWrappedNcgMinter.mint).not.toHaveBeenCalled();
+        });
+
         it("should record exchange history though mint failed", async () => {
             mockExchangeHistoryStore.transferredAmountInLast24Hours.mockResolvedValueOnce(0);
             mockWrappedNcgMinter.mint.mockRejectedValueOnce(new Error());

--- a/bridge/test/sqlite3-exchange-history-store.spec.ts
+++ b/bridge/test/sqlite3-exchange-history-store.spec.ts
@@ -20,6 +20,27 @@ describe("Sqlite3ExchangeHistoryStore", () => {
         }
     });
 
+    describe("exist", () => {
+        it("should return false if it doesn't exist.", async () => {
+            expect(await store.exist("TX-ID"))
+                .toBeFalsy();
+        });
+
+        it("should return true if it exist.", async () => {
+            store.put({
+                amount: 0,
+                network: "9c-main",
+                recipient: "ADDRESS",
+                sender: "ADDRESS",
+                timestamp: "timestamp",
+                tx_id: "TX-ID",
+            });
+
+            expect(await store.exist("TX-ID"))
+                .toBeTruthy();
+        });
+    });
+
     describe("transferredAmountInLast24Hours", () => {
         it("should return 0 if there is no record.", async () => {
             const network = "9c-main",


### PR DESCRIPTION
Originally, the bridge application avoids duplicate processing with SQLite's `UNIQUE` constraint. But it treats as an error though it was intended on the side. So this pull request makes it skip that and notify it as a warning to only slack.