### PR TITLE
fix(bridge): correct opensearch message field type

### DIFF
--- a/bridge/src/observers/burn-event-observer.ts
+++ b/bridge/src/observers/burn-event-observer.ts
@@ -58,7 +58,7 @@ export class EthereumBurnEventObserver implements IObserver<{ blockHash: BlockHa
                     ethereumTxId: transactionHash,
                     sender: sender,
                     recipient: recipient,
-                    amount: amountString,
+                    amount: amount.toNumber(),
                 });
                 console.log("Transferred", nineChroniclesTxId);
             } catch (e) {
@@ -72,7 +72,7 @@ export class EthereumBurnEventObserver implements IObserver<{ blockHash: BlockHa
                     ethereumTxId: transactionHash,
                     sender: sender,
                     recipient: recipient,
-                    amount: amountString,
+                    amount: amount.toNumber(),
                 });
                 await this._integration.error("Unexpected error during unwrapping NCG", {
                     errorMessage: String(e),

--- a/bridge/src/observers/nine-chronicles.ts
+++ b/bridge/src/observers/nine-chronicles.ts
@@ -131,7 +131,7 @@ export class NCGTransferredEventObserver implements IObserver<{ blockHash: Block
                         libplanetTxId: txId,
                         sender: sender,
                         recipient: recipient,
-                        amount: amountString,
+                        amount: amount.toNumber(),
                     });
                     console.log("Valid memo doesn't exist so refund NCG. The transaction's id is", nineChroniclesTxId);
                     continue;
@@ -154,7 +154,7 @@ export class NCGTransferredEventObserver implements IObserver<{ blockHash: Block
                         libplanetTxId: txId,
                         sender: sender,
                         recipient: recipient,
-                        amount: amountString,
+                        amount: amount.toNumber(),
                     });
                     console.log(`The amount(${amountString}) is less than ${this._limitationPolicy.minimum} so refund NCG. The transaction's id is`, nineChroniclesTxId);
                     continue;
@@ -173,7 +173,7 @@ export class NCGTransferredEventObserver implements IObserver<{ blockHash: Block
                         libplanetTxId: txId,
                         sender: sender,
                         recipient: recipient,
-                        amount: amountString,
+                        amount: amount.toNumber(),
                     });
                     console.log(`${sender} already exchanged ${transferredAmountInLast24Hours} and users can exchange until ${this._limitationPolicy.maximum} in 24 hours so refund NCG as ${amountString}. The transaction's id is`, nineChroniclesTxId);
                     continue;
@@ -184,8 +184,9 @@ export class NCGTransferredEventObserver implements IObserver<{ blockHash: Block
 
                 if (overflowedExchangeAmount) {
                     // Should equal with amount - limitedAmount
-                    refundAmount = transferredAmountInLast24Hours.add(amount).sub(maximum).toString();
-                    refundTxId = await this._ncgTransfer.transfer(sender, refundAmount, `I'm bridge and you should transfer less NCG than ${this._limitationPolicy.maximum}.`);
+                    const refundAmount = transferredAmountInLast24Hours.add(amount).sub(maximum);
+                    const refundAmountString = refundAmount.toString();
+                    refundTxId = await this._ncgTransfer.transfer(sender, refundAmountString, `I'm bridge and you should transfer less NCG than ${this._limitationPolicy.maximum}.`);
                     await this._slackWebClient.chat.postMessage({
                         channel: "#nine-chronicles-bridge-bot",
                         ...new RefundEvent(this._explorerUrl, sender, txId, amount, refundTxId, new Decimal(refundAmount), `${sender} tried to exchange ${amountString} and already exchanged ${transferredAmountInLast24Hours} and users can exchange until ${this._limitationPolicy.maximum} in 24 hours so refund NCG as ${refundAmount}`).render(),
@@ -195,10 +196,10 @@ export class NCGTransferredEventObserver implements IObserver<{ blockHash: Block
                         cause: `24 hr transfer maximum ${this._limitationPolicy.maximum} reached. User transferred ${transferredAmountInLast24Hours} NCGs in 24 hrs.`,
                         libplanetTxId: txId,
                         refundTxId: refundTxId,
-                        refundAmount: refundAmount,
+                        refundAmount: refundAmount.toNumber(),
                         sender: sender,
                         recipient: recipient,
-                        amount: amountString,
+                        amount: amount.toNumber(),
                     });
                     console.log(`${sender} tried to exchange ${amountString} and already exchanged ${transferredAmountInLast24Hours} and users can exchange until ${this._limitationPolicy.maximum} in 24 hours so refund NCG as ${refundAmount}. The transaction's id is`, refundTxId);
                 }
@@ -234,10 +235,10 @@ export class NCGTransferredEventObserver implements IObserver<{ blockHash: Block
                     content: "NCG -> wNCG request success",
                     libplanetTxId: txId,
                     ethereumTxId: transactionHash,
-                    fee: fee.toString(),
+                    fee: fee.toNumber(),
                     sender: sender,
                     recipient: recipient,
-                    amount: exchangeAmount.toString(),
+                    amount: exchangeAmount.toNumber(),
                 });
             } catch (e) {
                 console.log("EERRRR", e)

--- a/bridge/test/observers/__snapshots__/burn-event-observer.spec.ts.snap
+++ b/bridge/test/observers/__snapshots__/burn-event-observer.spec.ts.snap
@@ -20,7 +20,7 @@ Array [
   Array [
     "error",
     Object {
-      "amount": "1.00",
+      "amount": 1,
       "cause": "Error: mockNcgTransfer.transfer error",
       "content": "wNCG -> NCG request failure",
       "ethereumTxId": "TX-ID",
@@ -76,7 +76,7 @@ Array [
   Array [
     "info",
     Object {
-      "amount": "1.00",
+      "amount": 1,
       "content": "wNCG -> NCG request success",
       "ethereumTxId": "TX-ID",
       "libplanetTxId": "TX-HASH",

--- a/bridge/test/observers/__snapshots__/nine-chronicles.spec.ts.snap
+++ b/bridge/test/observers/__snapshots__/nine-chronicles.spec.ts.snap
@@ -76,10 +76,10 @@ Array [
   Array [
     "info",
     Object {
-      "amount": "99.23",
+      "amount": 99.23,
       "content": "NCG -> wNCG request success",
       "ethereumTxId": "TRANSACTION-HASH",
-      "fee": "1",
+      "fee": 1,
       "libplanetTxId": "TX-ID",
       "recipient": "0x4029bC50b4747A037d38CF2197bCD335e22Ca301",
       "sender": "0x2734048eC2892d111b4fbAB224400847544FC872",
@@ -249,7 +249,7 @@ Array [
   Array [
     "error",
     Object {
-      "amount": "1.23",
+      "amount": 1.23,
       "cause": "Invalid 9c transaction ID",
       "content": "NCG -> wNCG request failure",
       "libplanetTxId": "TX-ID",


### PR DESCRIPTION
Since #149, the bridge application has started to send processed transactions to OpenSearch. But the number fields like `fee` and `amount`, were treated as `string` types. Because of it, the fields were not able to be `aggregatable` so they can't be aggregated and visualized. This pull request fixed their types to `number` to resolve that situation.