### PR TITLE
feat(bridge): make opensearch index configurable

### DIFF
--- a/bridge/.env.example
+++ b/bridge/.env.example
@@ -74,3 +74,6 @@ PAGERDUTY_ROUTING_KEY="..."
 # The credentials for Open Search.
 OPENSEARCH_ENDPOINT=
 OPENSEARCH_AUTH=
+
+# The index's name of Open Search.
+OPENSEARCH_INDEX=

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -53,6 +53,7 @@ process.on("uncaughtException", console.error);
     const SLACK_WEB_TOKEN: string = Configuration.get("SLACK_WEB_TOKEN");
     const OPENSEARCH_ENDPOINT: string = Configuration.get("OPENSEARCH_ENDPOINT");
     const OPENSEARCH_AUTH: string = Configuration.get("OPENSEARCH_AUTH");
+    const OPENSEARCH_INDEX: string = Configuration.get("OPENSEARCH_INDEX", false) || "9c-eth-bridge";
     const EXPLORER_ROOT_URL: string = Configuration.get("EXPLORER_ROOT_URL");
     const ETHERSCAN_ROOT_URL: string = Configuration.get("ETHERSCAN_ROOT_URL");
     const SENTRY_DSN: string | undefined = Configuration.get("SENTRY_DSN", false);
@@ -78,7 +79,7 @@ process.on("uncaughtException", console.error);
     const monitorStateStore: IMonitorStateStore = await Sqlite3MonitorStateStore.open(MONITOR_STATE_STORE_PATH);
     const exchangeHistoryStore: IExchangeHistoryStore = await Sqlite3ExchangeHistoryStore.open(EXCHANGE_HISTORY_STORE_PATH);
     const slackWebClient = new WebClient(SLACK_WEB_TOKEN);
-    const opensearchClient = new OpenSearchClient(OPENSEARCH_ENDPOINT, OPENSEARCH_AUTH);
+    const opensearchClient = new OpenSearchClient(OPENSEARCH_ENDPOINT, OPENSEARCH_AUTH, OPENSEARCH_INDEX);
 
     const GRAPHQL_REQUEST_RETRY = 5;
     const headlessGraphQLCLient = new HeadlessGraphQLClient(GRAPHQL_API_ENDPOINT, GRAPHQL_REQUEST_RETRY);

--- a/bridge/src/opensearch-client.ts
+++ b/bridge/src/opensearch-client.ts
@@ -4,11 +4,12 @@ import { URL } from "url";
 export class OpenSearchClient {
     private readonly _opensearchEndpoint: string;
     private readonly _opensearchAuth: string;
-    private readonly _opensearchIndex: string = "9c-eth-bridge";
+    private readonly _opensearchIndex: string;
 
-    constructor(opensearchEndpoint: string, opensearchAuth: string) {
+    constructor(opensearchEndpoint: string, opensearchAuth: string, opensearchIndex: string) {
         this._opensearchEndpoint = opensearchEndpoint;
         this._opensearchAuth = opensearchAuth;
+        this._opensearchIndex = opensearchIndex;
     }
 
     async to_opensearch(level = "info", msg = {}, timeout = 3000) {

--- a/bridge/test/observers/burn-event-observer.spec.ts
+++ b/bridge/test/observers/burn-event-observer.spec.ts
@@ -47,7 +47,8 @@ describe(EthereumBurnEventObserver.name, () => {
 
     const mockOpenSearchClient = new OpenSearchClient(
         "https://www.random-url.com",
-        "auth"
+        "auth",
+        "9c-eth-bridge"
     ) as OpenSearchClient & {
         to_opensearch: ReturnType<typeof jest.fn>
     };

--- a/bridge/test/observers/nine-chronicles.spec.ts
+++ b/bridge/test/observers/nine-chronicles.spec.ts
@@ -55,7 +55,8 @@ describe(NCGTransferredEventObserver.name, () => {
 
     const mockOpenSearchClient = new OpenSearchClient(
         "https://www.random-url.com",
-        "auth"
+        "auth",
+        "9c-eth-bridge"
     ) as OpenSearchClient & {
         to_opensearch: ReturnType<typeof jest.fn>
     };


### PR DESCRIPTION
This pull request tries to resolve #167.

It started to provide a new environment variable, string-typed, named `OPENSEARCH_INDEX`, and the bridge application became to use the variable as the OpenSearch index name. If it wasn't given, it uses `9c-eth-bridge` as the default value.

Though I don't think it's related to the main feature of the OpenSearch, I requested a review because you're this feature's proposer. If you think this review request is not good, feel free to say about it. Then I'll not request reviews pull requests like this pull request. 🙏🏻 