### PR TITLE
feat(bridge): report when failed to fetch new block while 5 minutes

### DIFF
--- a/bridge/src/observers/timeout-observer.ts
+++ b/bridge/src/observers/timeout-observer.ts
@@ -1,0 +1,30 @@
+import { IObserver } from ".";
+import { Integration } from "../integrations";
+
+export class TimeoutObserver implements IObserver<unknown> {
+    private timer: NodeJS.Timeout;
+
+    private readonly _timeoutMilliseconds: number;
+    private readonly _integration: Integration;
+    private readonly _nodeKind: "nine-chronicles" | "ethereum";
+
+    constructor(integration: Integration, timeoutMilliseconds: number, nodeKind: "nine-chronicles" | "ethereum") {
+        this._integration = integration;
+        this._timeoutMilliseconds = timeoutMilliseconds;
+        this._nodeKind = nodeKind;
+
+        this.timer = setTimeout(this.report, this._timeoutMilliseconds);
+    }
+
+    async notify(data: unknown): Promise<void> {
+        clearTimeout(this.timer);
+        this.timer = setTimeout(this.report, this._timeoutMilliseconds);
+    }
+
+    private report(): void {
+        this._integration.error(
+            `The observing node (${this._nodeKind}) has not been updated for ${this._timeoutMilliseconds} ms.`,
+            {}
+        );
+    }
+}


### PR DESCRIPTION
This pull request resolves #172.

It introduces `TimeoutObserver` and reuses it in nine-chronicles and ethereum both. And it reports error when the observing node didn't notify well while 5 minutes.