### PR TITLE
Setup development environment again with localhost explorer

### DIFF
--- a/bridge/.env.development
+++ b/bridge/.env.development
@@ -1,9 +1,9 @@
 # The endpoint of GraphQL API to access Nine Chronicles network.
 # Its hostname and port should match with HTTP_ROOT_API_ENDPOINT's hostname and port.
-GRAPHQL_API_ENDPOINT="http://localhost:8808/graphql"
+GRAPHQL_API_ENDPOINT="http://localhost:5000/graphql"
 
 # Comma-separated headlesses to stage transactions. For chain data provider, please use `GRAPHQL_API_ENDPOINT` environment variable.
-STAGE_HEADLESSES="http://localhost:8808/graphql"
+STAGE_HEADLESSES="http://localhost:5000/graphql"
 
 # The Sentry DSN url to enable Sentry.
 # If you don't want to use Sentry, remove this envirionment variable.
@@ -28,7 +28,7 @@ MINIMUM_NCG="100"
 # See also https://github.com/planetarium/libplanet-explorer
 # See also https://github.com/planetarium/libplanet-explorer-frontend
 # See also https://explorer.libplanet.io/
-EXPLORER_ROOT_URL="https://explorer.libplanet.io/9c-internal/"
+EXPLORER_ROOT_URL="https://explorer.libplanet.io/localhost/"
 
 # The url of Etherscan.
 # For instance, https://ropsten.etherscan.io/, https://etherscan.io/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,10 +7,11 @@ services:
       - "--network-type=default"
       - "--host=localhost"
       - "--graphql-server"
-      - "--graphql-port=8808"
+      - "--graphql-port=5000"
       - "--store-type=rocksdb"
       - "--store-path=/tmp"
+      - "--no-cors"
       - "--miner-private-key=e803887ad70b94fc7bece28e7b7f36807aa6241b177035c38bbbaac7183a7c1b"  # Address = 0x2cBaDf26574756119cF705289C33710F27443767
       - "-G=https://download.nine-chronicles.com/empty-genesis-block"
     ports:
-      - 8808:8808
+      - 5000:5000


### PR DESCRIPTION
This pull request makes headless open `5000` number port to use `https://explorer.libplanet.io/localhost`.