### PR TITLE
docs(bridge): guide sqlite3 as prerequisite

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -11,6 +11,10 @@ v18.1.0
 # Python 2 should be installed and alias via python
 $ python --version
 Python 2.7.18
+
+# SQLite3 should be installed because it uses SQLite3 as database.
+$ command -v sqlite3
+/usr/bin/sqlite3
 ```
 
 ## Installation


### PR DESCRIPTION
This pull request resolves #153.

About the *Python 2* part, it was already resolved by https://github.com/planetarium/NineChronicles.EthBridge/commit/e5f86cbef59dbb7e20f0424f6543857b587e3ee9 🙇🏻‍♂️ 