### PR TITLE
feat(bridge): introduce `ZERO_EXCHANGE_FEE_RATIO_ADDRESSES` function

### DIFF
--- a/bridge/.env.example
+++ b/bridge/.env.example
@@ -80,3 +80,6 @@ OPENSEARCH_INDEX=
 
 # The Slack channel name to notify bridge events.
 SLACK_CHANNEL_NAME=
+
+# The addresses to apply zero exchange fee ratio.
+ZERO_EXCHANGE_FEE_RATIO_ADDRESSES=

--- a/bridge/src/policies/exchange-fee-ratio.ts
+++ b/bridge/src/policies/exchange-fee-ratio.ts
@@ -1,0 +1,52 @@
+import Decimal from "decimal.js";
+import { Address } from "../types/address";
+
+export interface IExchangeFeeRatioPolicy {
+    getFee(address: Address): Decimal | false;
+}
+
+export class FixedExchangeFeeRatioPolicy implements IExchangeFeeRatioPolicy {
+    private readonly _fee: Decimal;
+
+    constructor(fee: Decimal) {
+        this._fee = fee;
+    }
+
+    getFee(address: string): Decimal | false {
+        return this._fee;
+    }
+}
+
+export class ZeroExchangeFeeRatioPolicy implements IExchangeFeeRatioPolicy {
+    private readonly _address: Address;
+
+    constructor(address: Address) {
+        this._address = address
+    }
+
+    getFee(address: string): Decimal | false {
+        if (address === this._address) {
+            return new Decimal(0);
+        }
+
+        return false;
+    }
+}
+
+export class ExchnageFeePolicies implements IExchangeFeeRatioPolicy {
+    private readonly _policies: IExchangeFeeRatioPolicy[];
+
+    constructor(policies: IExchangeFeeRatioPolicy[]) {
+        this._policies = policies;
+    }
+
+    getFee(address: string): Decimal | false {
+        for (const policy of this._policies) {
+            const fee = policy.getFee(address);
+            if (fee !== false) {
+                return fee;
+            }
+        }
+        return false;
+    }
+}

--- a/bridge/test/observers/nine-chronicles.spec.ts
+++ b/bridge/test/observers/nine-chronicles.spec.ts
@@ -9,6 +9,7 @@ import { IExchangeHistoryStore } from "../../src/interfaces/exchange-history-sto
 import { IAddressBanPolicy } from "../../src/policies/address-ban";
 import { Integration } from "../../src/integrations";
 import { ISlackMessageSender } from "../../src/interfaces/slack-message-sender";
+import { FixedExchangeFeeRatioPolicy } from "../../src/policies/exchange-fee-ratio";
 
 jest.mock("@slack/web-api", () => {
     return {
@@ -64,7 +65,7 @@ describe(NCGTransferredEventObserver.name, () => {
         store: jest.fn(),
     };
 
-    const exchangeFeeRatio = new Decimal(0.01);
+    const exchangeFeeRatioPolicy = new FixedExchangeFeeRatioPolicy(new Decimal(0.01));
     const mockExchangeHistoryStore: jest.Mocked<IExchangeHistoryStore> = {
         put: jest.fn(),
         transferredAmountInLast24Hours: jest.fn(),
@@ -84,7 +85,7 @@ describe(NCGTransferredEventObserver.name, () => {
         error: jest.fn(),
     };
 
-    const observer = new NCGTransferredEventObserver(mockNcgTransfer, mockWrappedNcgMinter, mockSlackMessageSender, mockOpenSearchClient, mockMonitorStateStore, mockExchangeHistoryStore, "https://explorer.libplanet.io/9c-internal", "https://ropsten.etherscan.io", exchangeFeeRatio, limitationPolicy, addressBanPolicy, mockIntegration);
+    const observer = new NCGTransferredEventObserver(mockNcgTransfer, mockWrappedNcgMinter, mockSlackMessageSender, mockOpenSearchClient, mockMonitorStateStore, mockExchangeHistoryStore, "https://explorer.libplanet.io/9c-internal", "https://ropsten.etherscan.io", exchangeFeeRatioPolicy, limitationPolicy, addressBanPolicy, mockIntegration);
 
     describe(NCGTransferredEventObserver.prototype.notify.name, () => {
         beforeEach(() => {

--- a/bridge/test/policies/exchange-fee-ratio.spec.ts
+++ b/bridge/test/policies/exchange-fee-ratio.spec.ts
@@ -1,0 +1,34 @@
+import Decimal from "decimal.js";
+import { FixedExchangeFeeRatioPolicy, ZeroExchangeFeeRatioPolicy } from "../../src/policies/exchange-fee-ratio";
+
+describe(FixedExchangeFeeRatioPolicy.name, () => {
+    const addresses = [
+        "0x9093dd96c4bb6b44a9e0a522e2de49641f146223",
+        "0x939731b907cf30e34360670859d5440ab1a9503b",
+    ];
+    const exchangeFeeRatio = new Decimal(0.1);
+    const policy = new FixedExchangeFeeRatioPolicy(exchangeFeeRatio);
+
+    describe(FixedExchangeFeeRatioPolicy.prototype.getFee.name, () => {
+        it("should always return same value for every addresses", () => {
+            for (const address of addresses) {
+                expect(policy.getFee(address)).toEqual(new Decimal(0.1));
+            }
+        });
+    });
+});
+
+describe(ZeroExchangeFeeRatioPolicy.name, () => {
+    const policy = new ZeroExchangeFeeRatioPolicy("0x939731b907cf30e34360670859d5440ab1a9503b");
+
+    describe(ZeroExchangeFeeRatioPolicy.prototype.getFee.name, () => {
+        it("should always return zero value for target address", () => {
+            expect(policy.getFee("0x939731b907cf30e34360670859d5440ab1a9503b")).toEqual(new Decimal(0));
+        });
+
+        it("should always return false value for not target addresses", () => {
+            expect(policy.getFee("0x890d602ff01555b01b6cea1e2ca4c27b410b8fcc")).toBeFalsy();
+            expect(policy.getFee("0xe4f5351e02b1fd391712776a22db87884e02be5b")).toBeFalsy();
+        });
+    });
+});


### PR DESCRIPTION
This pull request introduces a new environment variable named `ZERO_EXCHANGE_FEE_RATIO_ADDRESSES`. It's a string consisting of addresses joined with `,`. The bridge application will not take exchange fees from the addresses.