### PR TITLE
feat(bridge): upgrade nodejs base image to 16.17

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:14.17 AS build-env
+FROM node:16.17 AS build-env
 
 COPY . /build
 WORKDIR /build
 RUN yarn
 RUN yarn tsc --project tsconfig.production.json
 
-FROM node:14.17-alpine
+FROM node:16.17-alpine
 
 COPY --from=build-env /build/dist /app
 COPY --from=build-env /build/node_modules /app/node_modules


### PR DESCRIPTION
This pull request bumps the base node image of the bridge Docker image to 16.17.

I bumped it because:

- Node.js 16.17 is current active LTS.
- Node.js 14.17 doesn't support Apple Silicon (darwin-arm64)
