### PR TITLE
feat(bridge): use 9cscan optionally

### DIFF
--- a/bridge/.env.example
+++ b/bridge/.env.example
@@ -29,6 +29,8 @@ MINIMUM_NCG="100"
 # See also https://github.com/planetarium/libplanet-explorer-frontend
 # See also https://explorer.libplanet.io/
 EXPLORER_ROOT_URL="https://explorer.libplanet.io/9c-internal/"
+NCSCAN_URL="https://9cscan.com"
+USE_NCSCAN_URL=FALSE
 
 # The url of Etherscan.
 # For instance, https://ropsten.etherscan.io/, https://etherscan.io/

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -91,6 +91,15 @@ process.on("uncaughtException", console.error);
         Configuration.get("SLACK_CHANNEL_NAME", false) ||
         "#nine-chronicles-bridge-bot";
     const EXPLORER_ROOT_URL: string = Configuration.get("EXPLORER_ROOT_URL");
+    const NCSCAN_URL: string | undefined = Configuration.get(
+        "NCSCAN_URL",
+        false
+    );
+    const USE_NCSCAN_URL: boolean = Configuration.get(
+        "USE_NCSCAN_URL",
+        false,
+        "boolean"
+    );
     const ETHERSCAN_ROOT_URL: string = Configuration.get("ETHERSCAN_ROOT_URL");
     const SENTRY_DSN: string | undefined = Configuration.get(
         "SENTRY_DSN",
@@ -256,6 +265,8 @@ process.on("uncaughtException", console.error);
         opensearchClient,
         monitorStateStore,
         EXPLORER_ROOT_URL,
+        NCSCAN_URL,
+        USE_NCSCAN_URL,
         ETHERSCAN_ROOT_URL,
         integration
     );
@@ -288,6 +299,8 @@ process.on("uncaughtException", console.error);
         monitorStateStore,
         exchangeHistoryStore,
         EXPLORER_ROOT_URL,
+        NCSCAN_URL,
+        USE_NCSCAN_URL,
         ETHERSCAN_ROOT_URL,
         ncgExchangeFeeRatioPolicy,
         {

--- a/bridge/src/messages/index.ts
+++ b/bridge/src/messages/index.ts
@@ -6,11 +6,3 @@ import { ForceOmit } from "../types/force-omit";
 export interface Message {
     render(): ForceOmit<ChatPostMessageArguments, "channel">;
 }
-
-export function combineUrl(base: string, addition: string): string {
-    const [path, query] = addition.split("?");
-    const url = new URL(base);
-    url.pathname = join(url.pathname, path);
-    url.search = `?${query || ""}`;
-    return url.toString();
-}

--- a/bridge/src/messages/refund-event.ts
+++ b/bridge/src/messages/refund-event.ts
@@ -1,5 +1,5 @@
 import { ChatPostMessageArguments } from "@slack/web-api";
-import { Message, combineUrl } from ".";
+import { Message } from ".";
 import { TxId } from "../types/txid";
 import { Address } from "../types/address";
 import { Decimal } from "decimal.js";

--- a/bridge/src/messages/refund-event.ts
+++ b/bridge/src/messages/refund-event.ts
@@ -4,6 +4,7 @@ import { TxId } from "../types/txid";
 import { Address } from "../types/address";
 import { Decimal } from "decimal.js";
 import { ForceOmit } from "../types/force-omit";
+import { combineNcExplorerUrl } from "./utils";
 
 export class RefundEvent implements Message {
     private readonly _sender: Address;
@@ -12,10 +13,14 @@ export class RefundEvent implements Message {
     private readonly _refundTxId: TxId;
     private readonly _refundAmount: Decimal;
     private readonly _explorerUrl: string;
+    private readonly _ncscanUrl: string | undefined;
+    private readonly _useNcscan: boolean;
     private readonly _reason: string;
 
     constructor(
         explorerUrl: string,
+        ncscanUrl: string | undefined,
+        useNcscan: boolean,
         sender: Address,
         requestTxId: TxId,
         requestAmount: Decimal,
@@ -29,6 +34,8 @@ export class RefundEvent implements Message {
         this._requestTxId = requestTxId;
         this._requestAmount = requestAmount;
         this._explorerUrl = explorerUrl;
+        this._ncscanUrl = ncscanUrl;
+        this._useNcscan = useNcscan;
         this._reason = reason;
     }
 
@@ -50,9 +57,11 @@ export class RefundEvent implements Message {
                         },
                         {
                             title: "Request transaction",
-                            value: combineUrl(
+                            value: combineNcExplorerUrl(
                                 this._explorerUrl,
-                                `transaction?${this._requestTxId}`
+                                this._ncscanUrl,
+                                this._useNcscan,
+                                this._requestTxId
                             ),
                         },
                         {
@@ -61,9 +70,11 @@ export class RefundEvent implements Message {
                         },
                         {
                             title: "Refund transaction",
-                            value: combineUrl(
+                            value: combineNcExplorerUrl(
                                 this._explorerUrl,
-                                `transaction?${this._refundTxId}`
+                                this._ncscanUrl,
+                                this._useNcscan,
+                                this._refundTxId
                             ),
                         },
                         {

--- a/bridge/src/messages/unwrapped-event.ts
+++ b/bridge/src/messages/unwrapped-event.ts
@@ -13,6 +13,8 @@ export class UnwrappedEvent extends WrappingEvent {
 
     constructor(
         explorerUrl: string,
+        ncscanUrl: string | undefined,
+        useNcscan: boolean,
         etherscanUrl: string,
         sender: Address,
         recipient: Address,
@@ -20,7 +22,7 @@ export class UnwrappedEvent extends WrappingEvent {
         nineChroniclesTxId: TxId,
         ethereumTransactionHash: string
     ) {
-        super(explorerUrl, etherscanUrl);
+        super(explorerUrl, ncscanUrl, useNcscan, etherscanUrl);
 
         this._sender = sender;
         this._recipient = recipient;

--- a/bridge/src/messages/unwrapping-failure-event.ts
+++ b/bridge/src/messages/unwrapping-failure-event.ts
@@ -39,7 +39,7 @@ export class UnwrappingFailureEvent implements Message {
                     fields: [
                         {
                             title: "Ethereum transaction",
-                            value: combineUrl(this._url, `/tx/${this._txId}`),
+                            value: combineUrl(this._url, `/tx/${this._txId}`, undefined),
                         },
                         {
                             title: "sender (Ethereum)",

--- a/bridge/src/messages/unwrapping-failure-event.ts
+++ b/bridge/src/messages/unwrapping-failure-event.ts
@@ -1,8 +1,9 @@
 import { ChatPostMessageArguments } from "@slack/web-api";
-import { combineUrl, Message } from ".";
+import { Message } from ".";
 import { TxId } from "../types/txid";
 import { Address } from "../types/address";
 import { ForceOmit } from "../types/force-omit";
+import { combineUrl } from "./utils";
 
 export class UnwrappingFailureEvent implements Message {
     private readonly _url: string;

--- a/bridge/src/messages/unwrapping-failure-event.ts
+++ b/bridge/src/messages/unwrapping-failure-event.ts
@@ -39,7 +39,11 @@ export class UnwrappingFailureEvent implements Message {
                     fields: [
                         {
                             title: "Ethereum transaction",
-                            value: combineUrl(this._url, `/tx/${this._txId}`, undefined),
+                            value: combineUrl(
+                                this._url,
+                                `/tx/${this._txId}`,
+                                undefined
+                            ),
                         },
                         {
                             title: "sender (Ethereum)",

--- a/bridge/src/messages/utils.ts
+++ b/bridge/src/messages/utils.ts
@@ -18,7 +18,11 @@ export function combineNcExplorerUrl(
     }
 }
 
-export function combineUrl(base: string, path: string, query: string | undefined): string {
+export function combineUrl(
+    base: string,
+    path: string,
+    query: string | undefined
+): string {
     const url = new URL(base);
     url.pathname = join(url.pathname, path);
     url.search = query || "";

--- a/bridge/src/messages/utils.ts
+++ b/bridge/src/messages/utils.ts
@@ -12,16 +12,15 @@ export function combineNcExplorerUrl(
             throw new Error("ncscanUrl is undefined");
         }
 
-        return combineUrl(ncscanUrl, `/tx/${txId}`);
+        return combineUrl(ncscanUrl, `/tx/${txId}`, undefined);
     } else {
-        return combineUrl(explorerUrl, `/transaction?${txId}`);
+        return combineUrl(explorerUrl, "/transaction", txId);
     }
 }
 
-export function combineUrl(base: string, addition: string): string {
-    const [path, query] = addition.split("?");
+export function combineUrl(base: string, path: string, query: string | undefined): string {
     const url = new URL(base);
     url.pathname = join(url.pathname, path);
-    url.search = `?${query || ""}`; // FIXME: remove ? when not required.
+    url.search = query || "";
     return url.toString();
 }

--- a/bridge/src/messages/utils.ts
+++ b/bridge/src/messages/utils.ts
@@ -1,0 +1,27 @@
+import { join } from "path";
+import { URL } from "url";
+
+export function combineNcExplorerUrl(
+    explorerUrl: string,
+    ncscanUrl: string | undefined,
+    useNcscan: boolean,
+    txId: string
+) {
+    if (useNcscan) {
+        if (ncscanUrl === undefined) {
+            throw new Error("ncscanUrl is undefined");
+        }
+
+        return combineUrl(ncscanUrl, `/tx/${txId}`);
+    } else {
+        return combineUrl(explorerUrl, `/transaction?${txId}`);
+    }
+}
+
+export function combineUrl(base: string, addition: string): string {
+    const [path, query] = addition.split("?");
+    const url = new URL(base);
+    url.pathname = join(url.pathname, path);
+    url.search = `?${query || ""}`; // FIXME: remove ? when not required.
+    return url.toString();
+}

--- a/bridge/src/messages/wrapped-event.ts
+++ b/bridge/src/messages/wrapped-event.ts
@@ -17,6 +17,8 @@ export class WrappedEvent extends WrappingEvent {
 
     constructor(
         explorerUrl: string,
+        ncscanUrl: string | undefined,
+        useNcscan: boolean,
         etherscanUrl: string,
         sender: Address,
         recipient: Address,
@@ -27,7 +29,7 @@ export class WrappedEvent extends WrappingEvent {
         refundAmount: string | null,
         refundTxId: TxId | null
     ) {
-        super(explorerUrl, etherscanUrl);
+        super(explorerUrl, ncscanUrl, useNcscan, etherscanUrl);
 
         this._sender = sender;
         this._recipient = recipient;

--- a/bridge/src/messages/wrapping-event.ts
+++ b/bridge/src/messages/wrapping-event.ts
@@ -4,31 +4,38 @@ import { TxId } from "../types/txid";
 import { URL } from "url";
 import { join, resolve } from "path";
 import { ForceOmit } from "../types/force-omit";
+import { combineNcExplorerUrl, combineUrl } from "./utils";
 
 export abstract class WrappingEvent implements Message {
     private readonly _explorerUrl: string;
+    private readonly _ncscanUrl: string | undefined;
+    protected readonly _useNcscan: boolean;
     private readonly _etherscanUrl: string;
 
-    constructor(explorerUrl: string, etherscanUrl: string) {
+    constructor(
+        explorerUrl: string,
+        ncscanUrl: string | undefined,
+        useNcscan: boolean,
+        etherscanUrl: string
+    ) {
         this._explorerUrl = explorerUrl;
+        this._ncscanUrl = ncscanUrl;
+        this._useNcscan = useNcscan;
         this._etherscanUrl = etherscanUrl;
     }
 
     abstract render(): ForceOmit<Partial<ChatPostMessageArguments>, "channel">;
 
     protected toExplorerUrl(txId: TxId): string {
-        return this.combineUrl(this._explorerUrl, `/transaction/?${txId}`);
+        return combineNcExplorerUrl(
+            this._explorerUrl,
+            this._ncscanUrl,
+            this._useNcscan,
+            txId
+        );
     }
 
     protected toEtherscanUrl(transactionHash: string): string {
-        return this.combineUrl(this._etherscanUrl, `/tx/${transactionHash}`);
-    }
-
-    private combineUrl(base: string, addition: string): string {
-        const [path, query] = addition.split("?");
-        const url = new URL(base);
-        url.pathname = join(url.pathname, path);
-        url.search = `?${query || ""}`;
-        return url.toString();
+        return combineUrl(this._etherscanUrl, `/tx/${transactionHash}`);
     }
 }

--- a/bridge/src/messages/wrapping-event.ts
+++ b/bridge/src/messages/wrapping-event.ts
@@ -36,6 +36,10 @@ export abstract class WrappingEvent implements Message {
     }
 
     protected toEtherscanUrl(transactionHash: string): string {
-        return combineUrl(this._etherscanUrl, `/tx/${transactionHash}`, undefined);
+        return combineUrl(
+            this._etherscanUrl,
+            `/tx/${transactionHash}`,
+            undefined
+        );
     }
 }

--- a/bridge/src/messages/wrapping-event.ts
+++ b/bridge/src/messages/wrapping-event.ts
@@ -36,6 +36,6 @@ export abstract class WrappingEvent implements Message {
     }
 
     protected toEtherscanUrl(transactionHash: string): string {
-        return combineUrl(this._etherscanUrl, `/tx/${transactionHash}`);
+        return combineUrl(this._etherscanUrl, `/tx/${transactionHash}`, undefined);
     }
 }

--- a/bridge/src/messages/wrapping-failure-event.ts
+++ b/bridge/src/messages/wrapping-failure-event.ts
@@ -3,9 +3,12 @@ import { combineUrl, Message } from ".";
 import { TxId } from "../types/txid";
 import { Address } from "../types/address";
 import { ForceOmit } from "../types/force-omit";
+import { combineNcExplorerUrl } from "./utils";
 
 export class WrappingFailureEvent implements Message {
     private readonly _url: string;
+    private readonly _ncscanUrl: string | undefined;
+    private readonly _useNcscan: boolean;
     private readonly _sender: Address;
     private readonly _recipient: Address;
     private readonly _txId: TxId;
@@ -14,6 +17,8 @@ export class WrappingFailureEvent implements Message {
 
     constructor(
         url: string,
+        ncscanUrl: string | undefined,
+        useNcscan: boolean,
         sender: Address,
         recipient: Address,
         amount: string,
@@ -21,6 +26,8 @@ export class WrappingFailureEvent implements Message {
         error: string
     ) {
         this._url = url;
+        this._ncscanUrl = ncscanUrl;
+        this._useNcscan = useNcscan;
         this._sender = sender;
         this._recipient = recipient;
         this._amount = amount;
@@ -38,9 +45,11 @@ export class WrappingFailureEvent implements Message {
                     fields: [
                         {
                             title: "9c network transaction",
-                            value: combineUrl(
+                            value: combineNcExplorerUrl(
                                 this._url,
-                                `/transaction?${this._txId}`
+                                this._ncscanUrl,
+                                this._useNcscan,
+                                this._txId
                             ),
                         },
                         {

--- a/bridge/src/messages/wrapping-failure-event.ts
+++ b/bridge/src/messages/wrapping-failure-event.ts
@@ -1,5 +1,5 @@
 import { ChatPostMessageArguments } from "@slack/web-api";
-import { combineUrl, Message } from ".";
+import { Message } from ".";
 import { TxId } from "../types/txid";
 import { Address } from "../types/address";
 import { ForceOmit } from "../types/force-omit";

--- a/bridge/src/observers/burn-event-observer.ts
+++ b/bridge/src/observers/burn-event-observer.ts
@@ -24,6 +24,8 @@ export class EthereumBurnEventObserver
     private readonly _slackMessageSender: ISlackMessageSender;
     private readonly _monitorStateStore: IMonitorStateStore;
     private readonly _explorerUrl: string;
+    private readonly _ncscanUrl: string | undefined;
+    private readonly _useNcscan: boolean;
     private readonly _etherscanUrl: string;
     private readonly _integration: Integration;
 
@@ -33,6 +35,8 @@ export class EthereumBurnEventObserver
         opensearchClient: OpenSearchClient,
         monitorStateStore: IMonitorStateStore,
         explorerUrl: string,
+        ncscanUrl: string | undefined,
+        useNcscan: boolean,
         etherscanUrl: string,
         integration: Integration
     ) {
@@ -41,6 +45,8 @@ export class EthereumBurnEventObserver
         this._opensearchClient = opensearchClient;
         this._monitorStateStore = monitorStateStore;
         this._explorerUrl = explorerUrl;
+        this._ncscanUrl = ncscanUrl;
+        this._useNcscan = useNcscan;
         this._etherscanUrl = etherscanUrl;
         this._integration = integration;
     }
@@ -84,6 +90,8 @@ export class EthereumBurnEventObserver
                 await this._slackMessageSender.sendMessage(
                     new UnwrappedEvent(
                         this._explorerUrl,
+                        this._ncscanUrl,
+                        this._useNcscan,
                         this._etherscanUrl,
                         sender,
                         recipient,

--- a/bridge/src/observers/nine-chronicles.ts
+++ b/bridge/src/observers/nine-chronicles.ts
@@ -48,6 +48,8 @@ export class NCGTransferredEventObserver
     private readonly _monitorStateStore: IMonitorStateStore;
     private readonly _exchangeHistoryStore: IExchangeHistoryStore;
     private readonly _explorerUrl: string;
+    private readonly _ncscanUrl: string | undefined;
+    private readonly _useNcscan: boolean;
     private readonly _etherscanUrl: string;
     /**
      * The fee ratio requried to exchange. This should be float value like 0.01.
@@ -66,6 +68,8 @@ export class NCGTransferredEventObserver
         monitorStateStore: IMonitorStateStore,
         exchangeHistoryStore: IExchangeHistoryStore,
         explorerUrl: string,
+        ncscanUrl: string | undefined,
+        useNcscan: boolean,
         etherscanUrl: string,
         exchangeFeeRatioPolicy: IExchangeFeeRatioPolicy,
         limitationPolicy: LimitationPolicy,
@@ -79,6 +83,8 @@ export class NCGTransferredEventObserver
         this._monitorStateStore = monitorStateStore;
         this._exchangeHistoryStore = exchangeHistoryStore;
         this._explorerUrl = explorerUrl;
+        this._ncscanUrl = ncscanUrl;
+        this._useNcscan = useNcscan;
         this._etherscanUrl = etherscanUrl;
         this._exchangeFeeRatioPolicy = exchangeFeeRatioPolicy;
         this._limitationPolicy = limitationPolicy;
@@ -181,6 +187,8 @@ export class NCGTransferredEventObserver
                     await this._slackMessageSender.sendMessage(
                         new RefundEvent(
                             this._explorerUrl,
+                            this._ncscanUrl,
+                            this._useNcscan,
                             sender,
                             txId,
                             amount,
@@ -220,6 +228,8 @@ export class NCGTransferredEventObserver
                     await this._slackMessageSender.sendMessage(
                         new RefundEvent(
                             this._explorerUrl,
+                            this._ncscanUrl,
+                            this._useNcscan,
                             sender,
                             txId,
                             amount,
@@ -253,6 +263,8 @@ export class NCGTransferredEventObserver
                     await this._slackMessageSender.sendMessage(
                         new RefundEvent(
                             this._explorerUrl,
+                            this._ncscanUrl,
+                            this._useNcscan,
                             sender,
                             txId,
                             amount,
@@ -293,6 +305,8 @@ export class NCGTransferredEventObserver
                     await this._slackMessageSender.sendMessage(
                         new RefundEvent(
                             this._explorerUrl,
+                            this._ncscanUrl,
+                            this._useNcscan,
                             sender,
                             txId,
                             amount,
@@ -365,6 +379,8 @@ export class NCGTransferredEventObserver
                 await this._slackMessageSender.sendMessage(
                     new WrappedEvent(
                         this._explorerUrl,
+                        this._ncscanUrl,
+                        this._useNcscan,
                         this._etherscanUrl,
                         sender,
                         recipient!,
@@ -398,6 +414,8 @@ export class NCGTransferredEventObserver
                 await this._slackMessageSender.sendMessage(
                     new WrappingFailureEvent(
                         this._explorerUrl,
+                        this._ncscanUrl,
+                        this._useNcscan,
                         sender,
                         String(recipient),
                         amountString,

--- a/bridge/test/messages/__snapshots__/unwrapped-event.spec.ts.snap
+++ b/bridge/test/messages/__snapshots__/unwrapped-event.spec.ts.snap
@@ -10,7 +10,7 @@ Object {
       "fields": Array [
         Object {
           "title": "9c network transaction",
-          "value": "https://explorer.libplanet.io/9c-internal/transaction/?3409cdbaa24ec6f7c8d2c0f636325a2b2e9611e5e6df5c593cfcd299860d8043",
+          "value": "https://explorer.libplanet.io/9c-internal/transaction?3409cdbaa24ec6f7c8d2c0f636325a2b2e9611e5e6df5c593cfcd299860d8043",
         },
         Object {
           "title": "Ethereum network transaction",

--- a/bridge/test/messages/__snapshots__/unwrapped-event.spec.ts.snap
+++ b/bridge/test/messages/__snapshots__/unwrapped-event.spec.ts.snap
@@ -14,7 +14,7 @@ Object {
         },
         Object {
           "title": "Ethereum network transaction",
-          "value": "https://ropsten.etherscan.io/tx/0x9360cd40682a91a71f0afbfac3dd381866cdb319dc01c13531dfe648f8a28bc7?",
+          "value": "https://ropsten.etherscan.io/tx/0x9360cd40682a91a71f0afbfac3dd381866cdb319dc01c13531dfe648f8a28bc7",
         },
         Object {
           "title": "sender (Ethereum)",

--- a/bridge/test/messages/__snapshots__/unwrapping-failure-event.spec.ts.snap
+++ b/bridge/test/messages/__snapshots__/unwrapping-failure-event.spec.ts.snap
@@ -10,7 +10,7 @@ Object {
       "fields": Array [
         Object {
           "title": "Ethereum transaction",
-          "value": "https://ropsten.etherscan.io/tx/0x9360cd40682a91a71f0afbfac3dd381866cdb319dc01c13531dfe648f8a28bc7?",
+          "value": "https://ropsten.etherscan.io/tx/0x9360cd40682a91a71f0afbfac3dd381866cdb319dc01c13531dfe648f8a28bc7",
         },
         Object {
           "title": "sender (Ethereum)",

--- a/bridge/test/messages/__snapshots__/wrapped-event.spec.ts.snap
+++ b/bridge/test/messages/__snapshots__/wrapped-event.spec.ts.snap
@@ -14,7 +14,7 @@ Object {
         },
         Object {
           "title": "Ethereum network transaction",
-          "value": "https://ropsten.etherscan.io/tx/0x9360cd40682a91a71f0afbfac3dd381866cdb319dc01c13531dfe648f8a28bc7?",
+          "value": "https://ropsten.etherscan.io/tx/0x9360cd40682a91a71f0afbfac3dd381866cdb319dc01c13531dfe648f8a28bc7",
         },
         Object {
           "title": "sender (NineChronicles)",
@@ -53,7 +53,7 @@ Object {
         },
         Object {
           "title": "Ethereum network transaction",
-          "value": "https://ropsten.etherscan.io/tx/0x9360cd40682a91a71f0afbfac3dd381866cdb319dc01c13531dfe648f8a28bc7?",
+          "value": "https://ropsten.etherscan.io/tx/0x9360cd40682a91a71f0afbfac3dd381866cdb319dc01c13531dfe648f8a28bc7",
         },
         Object {
           "title": "sender (NineChronicles)",

--- a/bridge/test/messages/__snapshots__/wrapped-event.spec.ts.snap
+++ b/bridge/test/messages/__snapshots__/wrapped-event.spec.ts.snap
@@ -10,7 +10,7 @@ Object {
       "fields": Array [
         Object {
           "title": "9c network transaction",
-          "value": "https://explorer.libplanet.io/9c-internal/transaction/?3409cdbaa24ec6f7c8d2c0f636325a2b2e9611e5e6df5c593cfcd299860d8043",
+          "value": "https://explorer.libplanet.io/9c-internal/transaction?3409cdbaa24ec6f7c8d2c0f636325a2b2e9611e5e6df5c593cfcd299860d8043",
         },
         Object {
           "title": "Ethereum network transaction",
@@ -49,7 +49,7 @@ Object {
       "fields": Array [
         Object {
           "title": "9c network transaction",
-          "value": "https://explorer.libplanet.io/9c-internal/transaction/?3409cdbaa24ec6f7c8d2c0f636325a2b2e9611e5e6df5c593cfcd299860d8043",
+          "value": "https://explorer.libplanet.io/9c-internal/transaction?3409cdbaa24ec6f7c8d2c0f636325a2b2e9611e5e6df5c593cfcd299860d8043",
         },
         Object {
           "title": "Ethereum network transaction",
@@ -77,7 +77,7 @@ Object {
         },
         Object {
           "title": "refund transaction",
-          "value": "https://explorer.libplanet.io/9c-internal/transaction/?a3cd151aa0cb24b3e692f433b857f08bd347dad0d2d6ca3666f26420b8b8d096",
+          "value": "https://explorer.libplanet.io/9c-internal/transaction?a3cd151aa0cb24b3e692f433b857f08bd347dad0d2d6ca3666f26420b8b8d096",
         },
       ],
     },

--- a/bridge/test/messages/unwrapped-event.spec.ts
+++ b/bridge/test/messages/unwrapped-event.spec.ts
@@ -4,6 +4,8 @@ describe("UnwrappedEvent", () => {
     describe("render", () => {
         it("snapshot", () => {
             const EXPLORER_URL = "https://explorer.libplanet.io/9c-internal";
+            const NCSCAN_URL = "https://9cscan.com";
+            const USE_NCSCAN_URL = false;
             const ETHERSCAN_URL = "https://ropsten.etherscan.io";
             const SENDER = "0xDac65eCE9CB3E7a538773e08DE31F973233F064f";
             const RECIPIENT = "0xCbfC996ad185c61a031f40CeeE80a055e6D83005";
@@ -15,6 +17,8 @@ describe("UnwrappedEvent", () => {
             expect(
                 new UnwrappedEvent(
                     EXPLORER_URL,
+                    NCSCAN_URL,
+                    USE_NCSCAN_URL,
                     ETHERSCAN_URL,
                     SENDER,
                     RECIPIENT,

--- a/bridge/test/messages/utils.spec.ts
+++ b/bridge/test/messages/utils.spec.ts
@@ -1,0 +1,58 @@
+import { combineNcExplorerUrl, combineUrl } from "../../src/messages/utils";
+
+describe(combineUrl.name, () => {
+    it("with query", () => {
+        expect(
+            combineUrl(
+                "https://explorer.libplanet.io/9c-internal/",
+                "/transaction",
+                "TX-ID"
+            )
+        ).toEqual(
+            "https://explorer.libplanet.io/9c-internal/transaction?TX-ID"
+        );
+    });
+
+    it("without query", () => {
+        expect(
+            combineUrl("https://9cscan.com/", "/tx/TX-ID", undefined)
+        ).toEqual("https://9cscan.com/tx/TX-ID");
+    });
+});
+
+describe(combineNcExplorerUrl.name, () => {
+    it("with explorer", () => {
+        expect(
+            combineNcExplorerUrl(
+                "https://explorer.libplanet.io/9c-internal/",
+                "https://9cscan.com/",
+                false,
+                "TX-ID"
+            )
+        ).toEqual(
+            "https://explorer.libplanet.io/9c-internal/transaction?TX-ID"
+        );
+    });
+
+    it("with ncscan", () => {
+        expect(
+            combineNcExplorerUrl(
+                "https://explorer.libplanet.io/9c-internal/",
+                "https://9cscan.com/",
+                true,
+                "TX-ID"
+            )
+        ).toEqual("https://9cscan.com/tx/TX-ID");
+    });
+
+    it("requires ncscanUrl argument when useNcscan is true", () => {
+        expect(() =>
+            combineNcExplorerUrl(
+                "https://explorer.libplanet.io/9c-internal/",
+                undefined,
+                true,
+                "TX-ID"
+            )
+        ).toThrowError("ncscanUrl is undefined");
+    });
+});

--- a/bridge/test/messages/wrapped-event.spec.ts
+++ b/bridge/test/messages/wrapped-event.spec.ts
@@ -5,6 +5,8 @@ describe("WrappedEvent", () => {
     describe("render", () => {
         it("snapshot", () => {
             const EXPLORER_URL = "https://explorer.libplanet.io/9c-internal";
+            const NCSCAN_URL = "https://9cscan.com";
+            const USE_NCSCAN_URL = false;
             const ETHERSCAN_URL = "https://ropsten.etherscan.io";
             const SENDER = "0xCbfC996ad185c61a031f40CeeE80a055e6D83005";
             const RECIPIENT = "0xDac65eCE9CB3E7a538773e08DE31F973233F064f";
@@ -17,6 +19,8 @@ describe("WrappedEvent", () => {
             expect(
                 new WrappedEvent(
                     EXPLORER_URL,
+                    NCSCAN_URL,
+                    USE_NCSCAN_URL,
                     ETHERSCAN_URL,
                     SENDER,
                     RECIPIENT,
@@ -32,6 +36,8 @@ describe("WrappedEvent", () => {
 
         it("snapshot with refund", () => {
             const EXPLORER_URL = "https://explorer.libplanet.io/9c-internal";
+            const NCSCAN_URL = "https://9cscan.com";
+            const USE_NCSCAN_URL = false;
             const ETHERSCAN_URL = "https://ropsten.etherscan.io";
             const SENDER = "0xCbfC996ad185c61a031f40CeeE80a055e6D83005";
             const RECIPIENT = "0xDac65eCE9CB3E7a538773e08DE31F973233F064f";
@@ -47,6 +53,8 @@ describe("WrappedEvent", () => {
             expect(
                 new WrappedEvent(
                     EXPLORER_URL,
+                    NCSCAN_URL,
+                    USE_NCSCAN_URL,
                     ETHERSCAN_URL,
                     SENDER,
                     RECIPIENT,

--- a/bridge/test/messages/wrapping-failure-event.spec.ts
+++ b/bridge/test/messages/wrapping-failure-event.spec.ts
@@ -4,6 +4,8 @@ describe("WrappingFailureEvent", () => {
     describe("render", () => {
         it("snapshot", () => {
             const EXPLORER_URL = "https://explorer.libplanet.io/9c-internal";
+            const NCSCAN_URL = "https://9cscan.com";
+            const USE_NCSCAN_URL = false;
             const SENDER = "0xCbfC996ad185c61a031f40CeeE80a055e6D83005";
             const RECIPIENT = "0xDac65eCE9CB3E7a538773e08DE31F973233F064f";
             const AMOUNT = "100";
@@ -12,6 +14,8 @@ describe("WrappingFailureEvent", () => {
             expect(
                 new WrappingFailureEvent(
                     EXPLORER_URL,
+                    NCSCAN_URL,
+                    USE_NCSCAN_URL,
                     SENDER,
                     RECIPIENT,
                     AMOUNT,

--- a/bridge/test/observers/__snapshots__/burn-event-observer.spec.ts.snap
+++ b/bridge/test/observers/__snapshots__/burn-event-observer.spec.ts.snap
@@ -43,7 +43,7 @@ Array [
           "fields": Array [
             Object {
               "title": "Ethereum transaction",
-              "value": "https://ropsten.etherscan.io/tx/TX-ID?",
+              "value": "https://ropsten.etherscan.io/tx/TX-ID",
             },
             Object {
               "title": "sender (Ethereum)",
@@ -102,7 +102,7 @@ Array [
             },
             Object {
               "title": "Ethereum network transaction",
-              "value": "https://ropsten.etherscan.io/tx/TX-ID?",
+              "value": "https://ropsten.etherscan.io/tx/TX-ID",
             },
             Object {
               "title": "sender (Ethereum)",

--- a/bridge/test/observers/__snapshots__/burn-event-observer.spec.ts.snap
+++ b/bridge/test/observers/__snapshots__/burn-event-observer.spec.ts.snap
@@ -98,7 +98,7 @@ Array [
           "fields": Array [
             Object {
               "title": "9c network transaction",
-              "value": "https://explorer.libplanet.io/9c-internal/transaction/?TX-HASH",
+              "value": "https://explorer.libplanet.io/9c-internal/transaction?TX-HASH",
             },
             Object {
               "title": "Ethereum network transaction",

--- a/bridge/test/observers/__snapshots__/nine-chronicles.spec.ts.snap
+++ b/bridge/test/observers/__snapshots__/nine-chronicles.spec.ts.snap
@@ -103,7 +103,7 @@ Array [
             },
             Object {
               "title": "Ethereum network transaction",
-              "value": "https://ropsten.etherscan.io/tx/TRANSACTION-HASH?",
+              "value": "https://ropsten.etherscan.io/tx/TRANSACTION-HASH",
             },
             Object {
               "title": "sender (NineChronicles)",

--- a/bridge/test/observers/__snapshots__/nine-chronicles.spec.ts.snap
+++ b/bridge/test/observers/__snapshots__/nine-chronicles.spec.ts.snap
@@ -99,7 +99,7 @@ Array [
           "fields": Array [
             Object {
               "title": "9c network transaction",
-              "value": "https://explorer.libplanet.io/9c-internal/transaction/?TX-ID",
+              "value": "https://explorer.libplanet.io/9c-internal/transaction?TX-ID",
             },
             Object {
               "title": "Ethereum network transaction",

--- a/bridge/test/observers/burn-event-observer.spec.ts
+++ b/bridge/test/observers/burn-event-observer.spec.ts
@@ -71,6 +71,8 @@ describe(EthereumBurnEventObserver.name, () => {
         mockOpenSearchClient,
         mockMonitorStateStore,
         "https://explorer.libplanet.io/9c-internal",
+        "https://9cscan.com",
+        false,
         "https://ropsten.etherscan.io",
         mockIntegration
     );

--- a/bridge/test/observers/nine-chronicles.spec.ts
+++ b/bridge/test/observers/nine-chronicles.spec.ts
@@ -102,6 +102,8 @@ describe(NCGTransferredEventObserver.name, () => {
         mockMonitorStateStore,
         mockExchangeHistoryStore,
         "https://explorer.libplanet.io/9c-internal",
+        "https://9cscan.com",
+        false,
         "https://ropsten.etherscan.io",
         exchangeFeeRatioPolicy,
         limitationPolicy,


### PR DESCRIPTION
This pull request introduces a new feature to use `9cscan.com` optionally.

Two new environment variables were introduced:

- `USE_NCSCAN_URL`: `boolean`
- `NCSCAN_URL`: `string`

----

- [x] Correct parsing and combining url.