### PR TITLE
refactor(bridge): make argument optional with `?` keyword

### DIFF
--- a/bridge/src/messages/unwrapping-failure-event.ts
+++ b/bridge/src/messages/unwrapping-failure-event.ts
@@ -39,11 +39,7 @@ export class UnwrappingFailureEvent implements Message {
                     fields: [
                         {
                             title: "Ethereum transaction",
-                            value: combineUrl(
-                                this._url,
-                                `/tx/${this._txId}`,
-                                undefined
-                            ),
+                            value: combineUrl(this._url, `/tx/${this._txId}`),
                         },
                         {
                             title: "sender (Ethereum)",

--- a/bridge/src/messages/utils.ts
+++ b/bridge/src/messages/utils.ts
@@ -12,17 +12,13 @@ export function combineNcExplorerUrl(
             throw new Error("ncscanUrl is undefined");
         }
 
-        return combineUrl(ncscanUrl, `/tx/${txId}`, undefined);
+        return combineUrl(ncscanUrl, `/tx/${txId}`);
     } else {
         return combineUrl(explorerUrl, "/transaction", txId);
     }
 }
 
-export function combineUrl(
-    base: string,
-    path: string,
-    query: string | undefined
-): string {
+export function combineUrl(base: string, path: string, query?: string): string {
     const url = new URL(base);
     url.pathname = join(url.pathname, path);
     url.search = query || "";

--- a/bridge/src/messages/wrapping-event.ts
+++ b/bridge/src/messages/wrapping-event.ts
@@ -36,10 +36,6 @@ export abstract class WrappingEvent implements Message {
     }
 
     protected toEtherscanUrl(transactionHash: string): string {
-        return combineUrl(
-            this._etherscanUrl,
-            `/tx/${transactionHash}`,
-            undefined
-        );
+        return combineUrl(this._etherscanUrl, `/tx/${transactionHash}`);
     }
 }

--- a/bridge/test/messages/utils.spec.ts
+++ b/bridge/test/messages/utils.spec.ts
@@ -14,9 +14,9 @@ describe(combineUrl.name, () => {
     });
 
     it("without query", () => {
-        expect(
-            combineUrl("https://9cscan.com/", "/tx/TX-ID", undefined)
-        ).toEqual("https://9cscan.com/tx/TX-ID");
+        expect(combineUrl("https://9cscan.com/", "/tx/TX-ID")).toEqual(
+            "https://9cscan.com/tx/TX-ID"
+        );
     });
 });
 


### PR DESCRIPTION
In TypeScript, there is `?` keyword, which makes an argument optional and uses `undefined` when it wasn't provided.

See also https://www.typescriptlang.org/docs/handbook/2/functions.html#optional-parameters.

This pull request resolves #192.