### PR TITLE
test(bridge): make aws-dependent tests' parameters configurable  totally

### DIFF
--- a/bridge/test/aws-dependent/ncg-kms-transfer.aws.spec.ts
+++ b/bridge/test/aws-dependent/ncg-kms-transfer.aws.spec.ts
@@ -1,26 +1,16 @@
-import { IHeadlessGraphQLClient } from "../../src/interfaces/headless-graphql-client";
 import { NCGKMSTransfer } from "../../src/ncg-kms-transfer";
 import { Configuration } from "../../src/configuration";
 import { HeadlessGraphQLClient } from "../../src/headless-graphql-client";
 import { KMSNCGSigner } from "../../src/kms-ncg-signer";
 
 describe(NCGKMSTransfer.name, () => {
-    const mockHeadlessGraphQlClient: jest.Mocked<IHeadlessGraphQLClient> = {
-        endpoint: "http://localhost:23061/graphql",
-        getBlockHash: jest.fn(),
-        getBlockIndex: jest.fn(),
-        getNCGTransferredEvents: jest.fn(),
-        getNextTxNonce: jest.fn((address) => Promise.resolve(0)),
-        getTipIndex: jest.fn(),
-        transfer: jest.fn(),
-        createUnsignedTx: jest.fn(),
-        attachSignature: jest.fn(),
-        stageTx: jest.fn(),
-    };
-    const mockAddress = "0x0000000000000000000000000000000000000000";
-    const mockPublicKey =
-        "BB/RQoardpERFnzxZs05Tj0Lq2gpyOGJUZ4nn6Oq1XnlkPRq1LN5HQqPdIOgYV73MbaSfW+VwPVpbtf/ViX51OE=";
-    const mockNcgMinterAddress = "0x99DF57BF45240C8a87615B0C884007501395d526";
+    const KMS_PROVIDER_ADDRESS: string = Configuration.get(
+        "TEST_KMS_PROVIDER_ADDRESS"
+    );
+    const KMS_PROVIDER_PUBLIC_KEY: string = Configuration.get(
+        "TEST_KMS_PROVIDER_PUBLIC_KEY"
+    );
+    const NCG_MINTER: string = Configuration.get("TEST_NCG_MINTER");
     const KMS_PROVIDER_KEY_ID: string = Configuration.get(
         "TEST_KMS_PROVIDER_KEY_ID"
     );
@@ -44,9 +34,9 @@ describe(NCGKMSTransfer.name, () => {
     );
     const ncgKmsTransfer = new NCGKMSTransfer(
         [headlessGraphQLCLient],
-        mockAddress,
-        mockPublicKey,
-        [mockNcgMinterAddress],
+        KMS_PROVIDER_ADDRESS,
+        KMS_PROVIDER_PUBLIC_KEY,
+        [NCG_MINTER],
         signer
     );
 


### PR DESCRIPTION
Before this pull request, it have to edit minter address, and KMS' address, public key in the code. This pull request just makes tests load them from `.env` file like KMS credentials.