### PR TITLE
fix(bridge): correct `setTimeout` usage

### DIFF
--- a/bridge/src/observers/timeout-observer.ts
+++ b/bridge/src/observers/timeout-observer.ts
@@ -17,17 +17,33 @@ export class TimeoutObserver implements IObserver<unknown> {
         this._timeoutMilliseconds = timeoutMilliseconds;
         this._nodeKind = nodeKind;
 
-        this.timer = setTimeout(this.report, this._timeoutMilliseconds);
+        this.timer = setTimeout(
+            this.report,
+            this._timeoutMilliseconds,
+            this._integration,
+            this._nodeKind,
+            this._timeoutMilliseconds
+        );
     }
 
     async notify(data: unknown): Promise<void> {
         clearTimeout(this.timer);
-        this.timer = setTimeout(this.report, this._timeoutMilliseconds);
+        this.timer = setTimeout(
+            this.report,
+            this._timeoutMilliseconds,
+            this._integration,
+            this._nodeKind,
+            this._timeoutMilliseconds
+        );
     }
 
-    private report(): void {
-        this._integration.error(
-            `The observing node (${this._nodeKind}) has not been updated for ${this._timeoutMilliseconds} ms.`,
+    private report(
+        integration: Integration,
+        nodeKind: "nine-chronicles" | "ethereum",
+        timeoutMilliseconds: number
+    ): void {
+        integration.error(
+            `The observing node (${nodeKind}) has not been updated for ${timeoutMilliseconds} ms.`,
             {}
         );
     }


### PR DESCRIPTION
When using `setTimeout(functionRef, delay, ...)`, the `functionRef`'s `this` seems to become dynamic. To pass the some value, it should give more parameters like `param1`, `param2`. (e.g., `setTimeout(func, 1000, 1, 2, 3)`).

It occurred errors and this pull request corrects it.