### PR TITLE
fix(bridge): set timeout while using GraphQL API

### DIFF
--- a/bridge/src/headless-graphql-client.ts
+++ b/bridge/src/headless-graphql-client.ts
@@ -177,6 +177,7 @@ export class HeadlessGraphQLClient implements IHeadlessGraphQLClient {
                 headers: {
                     "Content-Type": "application/json",
                 },
+                timeout: 10 * 1000,
             });
 
             if (response.data.errors) throw response.data.errors;


### PR DESCRIPTION
There was no timeout while using GraphQL API. This pull request sets it as 10s.