### PR TITLE
fix(bridge): correct txid calculation

### DIFF
--- a/bridge/src/ncg-kms-transfer.ts
+++ b/bridge/src/ncg-kms-transfer.ts
@@ -108,7 +108,7 @@ export class NCGKMSTransfer implements INCGTransfer {
             }
             const txId = crypto
                 .createHash("sha256")
-                .update(tx, "base64")
+                .update(tx, "hex")
                 .digest()
                 .toString("hex");
             return txId;


### PR DESCRIPTION
<img width="804" alt="image" src="https://user-images.githubusercontent.com/26626194/199896383-21439b65-82a1-4570-95fd-b5bb75d0bf54.png">

Since #202, the `tx` became a hexadecimal string but the logic to calculate txid wasn't changed. This pull request changes it.

```python
>>> # 's' is raw hexadecimal tx data
>>> m = hashlib.sha256(); m.update(bytes.fromhex(s)); m.digest().hex()
'503b8e53422b652d680f692e4755448971a7709546538c0767129c08edb62e55'
>>> m = hashlib.sha256(); m.update(base64.b64decode(s + "==")); m.digest().hex()
'd89485fc2417fbce04f6f5a9afecd7c6669d2860e666a645019c6d99107d6c57'
```