### PR TITLE
feat(bridge): update default `GAS_TIP_RATIO`

### DIFF
--- a/bridge/.env.development
+++ b/bridge/.env.development
@@ -62,7 +62,7 @@ PRIORITY_FEE=1
 
 # A ratio for gas tip. If the value is 0.1 and the Ethereum transaction gas price is 300 gwei,
 # it will use 330 gwei as gas price.
-GAS_TIP_RATIO="0.1"
+GAS_TIP_RATIO="1.3"
 
 # The maximum of gas price. Even if the network gas price is 400 and the MAX_GAS_PRICE is 300,
 # it will use 300 as gas price.


### PR DESCRIPTION
SSIA. Before this pull request, it usually fails to send transaction because its default value is `0.1` so it will use less gas price than the market gas price.