### PR TITLE
feat(bridge): use transfer_asset4

### DIFF
--- a/bridge/src/ncg-kms-transfer.ts
+++ b/bridge/src/ncg-kms-transfer.ts
@@ -61,7 +61,7 @@ export class NCGKMSTransfer implements INCGTransfer {
             // FIXME: request unsigned transaction builder API to NineChronicles.Headless developer
             //        and remove these lines.
             const plainValue = {
-                type_id: "transfer_asset3",
+                type_id: "transfer_asset4",
                 values: {
                     amount: [
                         {


### PR DESCRIPTION
Since v200030, the `transfer_asset3` became to have the plan to be obsoleted. We should apply this change until 7_200_000 block.

## LInks

 - https://github.com/planetarium/lib9c/blob/79d36a1f6c62dac3398e6c237fda7ef47aa13644/Lib9c/Action/TransferAsset3.cs#L25
 - https://github.com/planetarium/lib9c/blob/79d36a1f6c62dac3398e6c237fda7ef47aa13644/Lib9c/ActionObsoleteConfig.cs#L70