### PR TITLE
added tx parser for minting cli

### DIFF
--- a/scripts/tx_parser_for_minting_cli.py
+++ b/scripts/tx_parser_for_minting_cli.py
@@ -1,0 +1,58 @@
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.common.by import By
+import json
+
+# Tested with Chrome Version 114.0.5735.198 (Official Build) (arm64)
+
+# Set the path to the Chromium WebDriver executable
+webdriver_path = '/Users/admin/Downloads/chromedriver'
+
+# Configure the Chromium options
+chrome_options = webdriver.ChromeOptions()
+chrome_options.add_argument('--headless')  # Run in headless mode without opening a browser window
+
+s = Service(webdriver_path)
+driver = webdriver.Chrome(service=s, options=chrome_options)
+
+print('9c-scan TX URL:')
+url = input()
+if not url[:22] == 'https://9cscan.com/tx/':
+    print('URL should start with https://9cscan.com/tx/...')
+    exit(1)
+
+# Navigate to the desired URL
+print("Loading...")
+driver.get(url)
+print("")
+
+# NCG Transfer Requested Amount
+ncg_transfer_amount = driver.find_element(By.XPATH, '/html/body/div/div/div[3]/div/div[2]/div[2]/div[4]/div[2]')
+
+# 100 == 1.00 NCG, 41630 == 416.30 NCG, 500000 = 5000.00 NCG
+parsed_data = json.loads(ncg_transfer_amount.text.strip())
+amount = int(parsed_data[1])
+fee = 1000 # 10.00 fixed NCG when requested amount is less than 1000.00 NCG
+if amount > 100000: # > 1000.00 NCG
+    fee = amount * 0.01
+fee = int(fee)
+final_amount = int(amount - fee)
+final_amount_str = str(final_amount)[0:-2] + '.' + str(final_amount)[-2:]
+print("NCG Requested:", amount, "/ Fee:", fee, "/ Final:", final_amount)
+
+# Sender
+sender = driver.find_element(By.XPATH, '/html/body/div/div/div[3]/div/div[2]/div[2]/div[7]/div[2]')
+sender = sender.text.strip()
+print("Sender (9c):", sender)
+
+# Memo
+memo = driver.find_element(By.XPATH, '/html/body/div/div/div[3]/div/div[2]/div[2]/div[5]/div[2]')
+memo = memo.text.strip()
+print("Recipient (ETH):", memo)
+print("")
+
+# Bridge CLI CMD
+print(">> npm run mint", memo, final_amount_str)
+
+# Close the browser
+driver.quit()


### PR DESCRIPTION
```

(base) admin@ARYs-MacBook-Pro scripts % python tx_parser_for_minting_cli.py 

9c-scan TX URL:
https://9cscan.com/tx/2c6f6b02f6466f5ba517ebd22e754b49fa2cb83cad9f7c20a8981f291116003a
Loading...

NCG Requested: 41630 / Fee: 1000 / Final: 40630
Sender (9c): 0x6c9d5b2f90ad4dea01ea037a9dfd883b4b875e14
Recipient (ETH): 0x927d1e13d8786d969e13F8fE9e41656842c12C7B

>> npm run mint 0x927d1e13d8786d969e13F8fE9e41656842c12C7B 406.30
```