### PR TITLE
feat: update fallback provider weight

### DIFF
--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -382,8 +382,8 @@ process.on("uncaughtException", console.error);
 
     const provider = new ethers.providers.FallbackProvider(
         [
-            { provider: providerMain, priority: 0 },
-            { provider: providerSub, priority: 1 },
+            { provider: providerMain, priority: 1, weight: 2 },
+            { provider: providerSub, priority: 2, weight: 1 },
         ],
         1
     );


### PR DESCRIPTION
Set each providers' weight to make sub_provider's failure not to effect to the whole providers to be failed.