### PR TITLE
Feature/awssdk

### DIFF
--- a/bridge/src/ethers-aws-kms-signer.ts
+++ b/bridge/src/ethers-aws-kms-signer.ts
@@ -1,5 +1,9 @@
 import { ethers, UnsignedTransaction } from "ethers";
-import { KMS } from "aws-sdk";
+import {
+    KMSClient,
+    SignCommand,
+    GetPublicKeyCommand,
+} from "@aws-sdk/client-kms";
 // @ts-ignore
 import * as asn1 from "asn1.js";
 import BN from "bn.js";
@@ -28,26 +32,24 @@ export async function sign(
     digest: Buffer,
     kmsCredentials: AwsKmsSignerCredentials
 ) {
-    const kms = new KMS(kmsCredentials);
-    const params: KMS.SignRequest = {
-        // key id or 'Alias/<alias>'
+    const kms = new KMSClient({ region: kmsCredentials.region });
+    const params = {
         KeyId: kmsCredentials.keyId,
         Message: digest,
-        // 'ECDSA_SHA_256' is the one compatible with ECC_SECG_P256K1.
-        SigningAlgorithm: "ECDSA_SHA_256",
-        MessageType: "DIGEST",
+        SigningAlgorithm: "ECDSA_SHA_256" as const,
+        MessageType: "DIGEST" as const,
     };
-    const res = await kms.sign(params).promise();
+    const command = new SignCommand(params);
+    const res = await kms.send(command);
     return res;
 }
 
 export async function getPublicKey(kmsCredentials: AwsKmsSignerCredentials) {
-    const kms = new KMS(kmsCredentials);
-    return kms
-        .getPublicKey({
-            KeyId: kmsCredentials.keyId,
-        })
-        .promise();
+    const kms = new KMSClient({ region: kmsCredentials.region });
+    const command = new GetPublicKeyCommand({
+        KeyId: kmsCredentials.keyId,
+    });
+    return kms.send(command);
 }
 
 export function getEthereumAddress(publicKey: Buffer): string {
@@ -88,10 +90,8 @@ export async function requestKmsSignature(
     kmsCredentials: AwsKmsSignerCredentials
 ) {
     const signature = await sign(plaintext, kmsCredentials);
-    if (signature.$response.error || signature.Signature === undefined) {
-        throw new Error(
-            `AWS KMS call failed with: ${signature.$response.error}`
-        );
+    if (!signature.Signature) {
+        throw new Error(`AWS KMS call failed: Signature is undefined`);
     }
     return findEthereumSig(signature.Signature as Buffer);
 }
@@ -152,8 +152,11 @@ export class AwsKmsSigner extends ethers.Signer {
     async getAddress(): Promise<string> {
         if (this.ethereumAddress === undefined) {
             const key = await getPublicKey(this.kmsCredentials);
+
+            const publicKeyBuffer = Buffer.from(key.PublicKey as Uint8Array);
+
             this.ethereumAddress = ethers.utils.getAddress(
-                getEthereumAddress(key.PublicKey as Buffer)
+                getEthereumAddress(publicKeyBuffer)
             );
         }
         return Promise.resolve(this.ethereumAddress);


### PR DESCRIPTION
In AWS SDK v3, `Uint8Array` is used instead of `Buffer`, so conversion between `Buffer` and `Uint8Array` is necessary